### PR TITLE
split PulsarCommand DU

### DIFF
--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -22,23 +22,25 @@ type CnxOperation =
     | RemoveProducer of ProducerId
     | ChannelInactive
 
-type PulsarCommands =
-    | XCommandConnected of CommandConnected * SequencePosition
-    | XCommandPartitionedTopicMetadataResponse of CommandPartitionedTopicMetadataResponse * SequencePosition
-    | XCommandSendReceipt of CommandSendReceipt * SequencePosition
-    | XCommandMessage of (CommandMessage * MessageMetadata * byte[] ) * SequencePosition
-    | XCommandPing of CommandPing * SequencePosition
-    | XCommandLookupTopicResponse of CommandLookupTopicResponse * SequencePosition
-    | XCommandProducerSuccess of CommandProducerSuccess * SequencePosition
-    | XCommandSuccess of CommandSuccess * SequencePosition
-    | XCommandSendError of CommandSendError * SequencePosition
-    | XCommandGetTopicsOfNamespaceResponse of CommandGetTopicsOfNamespaceResponse * SequencePosition
-    | XCommandCloseProducer of CommandCloseProducer * SequencePosition
-    | XCommandCloseConsumer of CommandCloseConsumer * SequencePosition
-    | XCommandReachedEndOfTopic of CommandReachedEndOfTopic * SequencePosition
-    | XCommandError of CommandError * SequencePosition
+type PulsarCommand =
+    | XCommandConnected of CommandConnected
+    | XCommandPartitionedTopicMetadataResponse of CommandPartitionedTopicMetadataResponse
+    | XCommandSendReceipt of CommandSendReceipt
+    | XCommandMessage of (CommandMessage * MessageMetadata * byte[] )
+    | XCommandPing of CommandPing
+    | XCommandLookupTopicResponse of CommandLookupTopicResponse
+    | XCommandProducerSuccess of CommandProducerSuccess
+    | XCommandSuccess of CommandSuccess
+    | XCommandSendError of CommandSendError
+    | XCommandGetTopicsOfNamespaceResponse of CommandGetTopicsOfNamespaceResponse
+    | XCommandCloseProducer of CommandCloseProducer
+    | XCommandCloseConsumer of CommandCloseConsumer
+    | XCommandReachedEndOfTopic of CommandReachedEndOfTopic
+    | XCommandError of CommandError
+
+type CommandParseError =
     | IncompleteCommand
-    | InvalidCommand of Exception
+    | UnknownCommandType of BaseCommand.Type
 
 type SocketMessage =
     | SocketMessageWithReply of Payload * AsyncReplyChannel<unit>
@@ -123,73 +125,68 @@ type ClientCnx (broker: Broker,
 
     let tryParse (buffer: ReadOnlySequence<byte>) readerId =
         let array = buffer.ToArray()
-        if (array.Length >= 8)
-        then
+        if (array.Length <= 8)
+        then Result.Error IncompleteCommand
+        else
             use stream =  new MemoryStream(array)
             use reader = new BinaryReader(stream)
 
             let totalength = reader.ReadInt32() |> int32FromBigEndian
             let frameLength = totalength + 4
 
-            if (frameLength <= array.Length)
-            then
-                try
-                    let command = Serializer.DeserializeWithLengthPrefix<BaseCommand>(stream, PrefixStyle.Fixed32BigEndian)
-                    Log.Logger.LogDebug("[{0}] Got message of type {1}", readerId, command.``type``)
-                    match command.``type`` with
-                    | BaseCommand.Type.Connected ->
-                        XCommandConnected (command.Connected, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.PartitionedMetadataResponse ->
-                        XCommandPartitionedTopicMetadataResponse (command.partitionMetadataResponse, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.SendReceipt ->
-                        XCommandSendReceipt (command.SendReceipt, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.Message ->
-                        reader.ReadInt16() |> int16FromBigEndian |> invalidArgIf ((<>) MagicNumber) "Invalid magicNumber" |> ignore
-                        let messageCheckSum  = reader.ReadInt32() |> int32FromBigEndian
-                        let metadataPointer = stream.Position
-                        let metatada = Serializer.DeserializeWithLengthPrefix<MessageMetadata>(stream, PrefixStyle.Fixed32BigEndian)
-                        let payloadPointer = stream.Position
-                        let metadataLength = payloadPointer - metadataPointer |> int
-                        let payloadLength = frameLength - (int payloadPointer)
-                        let payload = reader.ReadBytes(payloadLength)
-                        stream.Seek(metadataPointer, SeekOrigin.Begin) |> ignore
-                        CRC32C.Get(0u, stream, metadataLength + payloadLength) |> int32 |> invalidArgIf ((<>) messageCheckSum) "Invalid checksum" |> ignore
-                        XCommandMessage ((command.Message, metatada, payload), buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.LookupResponse ->
-                        XCommandLookupTopicResponse (command.lookupTopicResponse, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.Ping ->
-                        XCommandPing (command.Ping, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.ProducerSuccess ->
-                        XCommandProducerSuccess (command.ProducerSuccess, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.Success ->
-                        XCommandSuccess (command.Success, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.SendError ->
-                        XCommandSendError (command.SendError, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.CloseProducer ->
-                        XCommandCloseProducer (command.CloseProducer, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.CloseConsumer ->
-                        XCommandCloseConsumer (command.CloseConsumer, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.ReachedEndOfTopic ->
-                        XCommandReachedEndOfTopic (command.reachedEndOfTopic, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.GetTopicsOfNamespaceResponse ->
-                        XCommandGetTopicsOfNamespaceResponse (command.getTopicsOfNamespaceResponse, buffer.GetPosition(int64 frameLength))
-                    | BaseCommand.Type.Error ->
-                        XCommandError (command.Error, buffer.GetPosition(int64 frameLength))
-                    | _ as unknownCommandType ->
-                        InvalidCommand (Exception(sprintf "Unknown command type: '%A'" unknownCommandType))
-                with
-                | ex ->
-                    InvalidCommand ex
+            if (array.Length <= frameLength)
+            then Result.Error IncompleteCommand
             else
-                IncompleteCommand
-        else
-            IncompleteCommand
+                let command = Serializer.DeserializeWithLengthPrefix<BaseCommand>(stream, PrefixStyle.Fixed32BigEndian)
+                Log.Logger.LogDebug("[{0}] Got message of type {1}", readerId, command.``type``)
+                let consumed = int64 frameLength |> buffer.GetPosition
+                match command.``type`` with
+                | BaseCommand.Type.Connected ->
+                    Ok (XCommandConnected command.Connected, consumed)
+                | BaseCommand.Type.PartitionedMetadataResponse ->
+                    Ok (XCommandPartitionedTopicMetadataResponse command.partitionMetadataResponse, consumed)
+                | BaseCommand.Type.SendReceipt ->
+                    Ok (XCommandSendReceipt command.SendReceipt, consumed)
+                | BaseCommand.Type.Message ->
+                    reader.ReadInt16() |> int16FromBigEndian |> invalidArgIf ((<>) MagicNumber) "Invalid magicNumber" |> ignore
+                    let messageCheckSum  = reader.ReadInt32() |> int32FromBigEndian
+                    let metadataPointer = stream.Position
+                    let metatada = Serializer.DeserializeWithLengthPrefix<MessageMetadata>(stream, PrefixStyle.Fixed32BigEndian)
+                    let payloadPointer = stream.Position
+                    let metadataLength = payloadPointer - metadataPointer |> int
+                    let payloadLength = frameLength - (int payloadPointer)
+                    let payload = reader.ReadBytes(payloadLength)
+                    stream.Seek(metadataPointer, SeekOrigin.Begin) |> ignore
+                    CRC32C.Get(0u, stream, metadataLength + payloadLength) |> int32 |> invalidArgIf ((<>) messageCheckSum) "Invalid checksum" |> ignore
+                    Ok (XCommandMessage (command.Message, metatada, payload), consumed)
+                | BaseCommand.Type.LookupResponse ->
+                    Ok (XCommandLookupTopicResponse command.lookupTopicResponse, consumed)
+                | BaseCommand.Type.Ping ->
+                    Ok (XCommandPing command.Ping, consumed)
+                | BaseCommand.Type.ProducerSuccess ->
+                    Ok (XCommandProducerSuccess command.ProducerSuccess, consumed)
+                | BaseCommand.Type.Success ->
+                    Ok (XCommandSuccess command.Success, consumed)
+                | BaseCommand.Type.SendError ->
+                    Ok (XCommandSendError command.SendError, consumed)
+                | BaseCommand.Type.CloseProducer ->
+                    Ok (XCommandCloseProducer command.CloseProducer, consumed)
+                | BaseCommand.Type.CloseConsumer ->
+                    Ok (XCommandCloseConsumer command.CloseConsumer, consumed)
+                | BaseCommand.Type.ReachedEndOfTopic ->
+                    Ok (XCommandReachedEndOfTopic command.reachedEndOfTopic, consumed)
+                | BaseCommand.Type.GetTopicsOfNamespaceResponse ->
+                    Ok (XCommandGetTopicsOfNamespaceResponse command.getTopicsOfNamespaceResponse, consumed)
+                | BaseCommand.Type.Error ->
+                    Ok (XCommandError command.Error, consumed)
+                | unknownType ->
+                    Result.Error (UnknownCommandType unknownType)
 
     let handleRespone requestId result (reader: PipeReader) consumed =
         let tsc = requests.[requestId]
-        tsc.SetResult(result)
-        requests.Remove(requestId) |> ignore
-        reader.AdvanceTo(consumed)
+        tsc.SetResult result
+        requests.Remove requestId |> ignore
+        reader.AdvanceTo consumed
 
     let readSocket () =
         task {
@@ -212,73 +209,75 @@ type ClientCnx (broker: Broker,
                     continueLooping <- false
                 else
                     match tryParse buffer readerId with
-                    | XCommandConnected (cmd, consumed) ->
-                        //TODO check server protocol version
-                        initialConnectionTsc.SetResult(this)
-                        reader.AdvanceTo(consumed)
-                    | XCommandPartitionedTopicMetadataResponse (cmd, consumed) ->
-                        let result =
-                            if (cmd.ShouldSerializeError())
-                            then
-                                Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
-                                Error
-                            else
-                                PartitionedTopicMetadata { Partitions = cmd.Partitions }
-                        handleRespone %cmd.RequestId result reader consumed
-                    | XCommandSendReceipt (cmd, consumed) ->
-                        let producerMb = producers.[%cmd.ProducerId]
-                        producerMb.Post(SendReceipt cmd)
-                        reader.AdvanceTo(consumed)
-                    | XCommandSendError (cmd, consumed) ->
-                        let producerMb = producers.[%cmd.ProducerId]
-                        producerMb.Post(SendError cmd)
-                        reader.AdvanceTo(consumed)
-                    | XCommandPing (cmd, consumed) ->
-                        sendMb.Post(SocketMessageWithoutReply (Commands.newPong()))
-                        reader.AdvanceTo(consumed)
-                    | XCommandMessage ((cmd, metadata, payload), consumed) ->
-                        let consumerMb = consumers.[%cmd.ConsumerId]
-                        consumerMb.Post(MessageRecieved { MessageId = MessageId.FromMessageIdData(cmd.MessageId); Payload = payload })
-                        reader.AdvanceTo(consumed)
-                    | XCommandLookupTopicResponse (cmd, consumed) ->
-                        let result =
-                            if (cmd.ShouldSerializeError())
-                            then
-                                Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
-                                Error
-                            else
-                                LookupTopicResult { BrokerServiceUrl = cmd.brokerServiceUrl; Proxy = cmd.ProxyThroughServiceUrl }
-                        handleRespone %cmd.RequestId result reader consumed
-                    | XCommandProducerSuccess (cmd, consumed) ->
-                        let result = ProducerSuccess { GeneratedProducerName = cmd.ProducerName }
-                        handleRespone %cmd.RequestId result reader consumed
-                    | XCommandSuccess (cmd, consumed) ->
-                        handleRespone %cmd.RequestId Empty reader consumed
-                    | XCommandCloseProducer (cmd, consumed) ->
-                        let producerMb = producers.[%cmd.ProducerId]
-                        producers.Remove(%cmd.ProducerId) |> ignore
-                        producerMb.Post(ProducerMessage.ConnectionClosed)
-                        reader.AdvanceTo(consumed)
-                    | XCommandCloseConsumer (cmd, consumed) ->
-                        let consumerMb = consumers.[%cmd.ConsumerId]
-                        consumers.Remove(%cmd.ConsumerId) |> ignore
-                        consumerMb.Post(ConsumerMessage.ConnectionClosed)
-                        reader.AdvanceTo(consumed)
-                    | XCommandReachedEndOfTopic (cmd, consumed) ->
-                        let consumerMb = consumers.[%cmd.ConsumerId]
-                        consumerMb.Post ReachedEndOfTheTopic
-                        reader.AdvanceTo(consumed)
-                    | XCommandGetTopicsOfNamespaceResponse (cmd, consumed) ->
-                        let result = TopicsOfNamespace { Topics = List.ofSeq cmd.Topics }
-                        handleRespone %cmd.RequestId result reader consumed
-                    | XCommandError (cmd, consumed) ->
-                        Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
-                        let result = Error
-                        handleRespone %cmd.RequestId result reader consumed
-                    | IncompleteCommand ->
+                    | Result.Error IncompleteCommand ->
                         reader.AdvanceTo(buffer.Start, buffer.End)
-                    | InvalidCommand ex ->
-                        raise ex
+                    | Result.Error (UnknownCommandType unknownType) ->
+                        failwithf "Unknown command type %A" unknownType
+                    | Result.Ok (xcmd, consumed) ->
+                        match xcmd with
+                        | XCommandConnected _ ->
+                            //TODO check server protocol version
+                            initialConnectionTsc.SetResult(this)
+                            reader.AdvanceTo consumed
+                        | XCommandPartitionedTopicMetadataResponse cmd ->
+                            let result =
+                                if (cmd.ShouldSerializeError())
+                                then
+                                    Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
+                                    Error
+                                else
+                                    PartitionedTopicMetadata { Partitions = cmd.Partitions }
+                            handleRespone %cmd.RequestId result reader consumed
+                        | XCommandSendReceipt cmd ->
+                            let producerMb = producers.[%cmd.ProducerId]
+                            producerMb.Post(SendReceipt cmd)
+                            reader.AdvanceTo consumed
+                        | XCommandSendError cmd ->
+                            let producerMb = producers.[%cmd.ProducerId]
+                            producerMb.Post(SendError cmd)
+                            reader.AdvanceTo consumed
+                        | XCommandPing _ ->
+                            Commands.newPong() |> SocketMessageWithoutReply |> sendMb.Post
+                            reader.AdvanceTo consumed
+                        | XCommandMessage (cmd, _, payload) ->
+                            let consumerMb = consumers.[%cmd.ConsumerId]
+                            consumerMb.Post(MessageRecieved { MessageId = MessageId.FromMessageIdData(cmd.MessageId); Payload = payload })
+                            reader.AdvanceTo consumed
+                        | XCommandLookupTopicResponse cmd ->
+                            let result =
+                                if (cmd.ShouldSerializeError())
+                                then
+                                    Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
+                                    Error
+                                else
+                                    LookupTopicResult { BrokerServiceUrl = cmd.brokerServiceUrl; Proxy = cmd.ProxyThroughServiceUrl }
+                            handleRespone %cmd.RequestId result reader consumed
+                        | XCommandProducerSuccess cmd ->
+                            let result = ProducerSuccess { GeneratedProducerName = cmd.ProducerName }
+                            handleRespone %cmd.RequestId result reader consumed
+                        | XCommandSuccess cmd ->
+                            handleRespone %cmd.RequestId Empty reader consumed
+                        | XCommandCloseProducer cmd ->
+                            let producerMb = producers.[%cmd.ProducerId]
+                            producers.Remove(%cmd.ProducerId) |> ignore
+                            producerMb.Post ProducerMessage.ConnectionClosed
+                            reader.AdvanceTo consumed
+                        | XCommandCloseConsumer cmd ->
+                            let consumerMb = consumers.[%cmd.ConsumerId]
+                            consumers.Remove(%cmd.ConsumerId) |> ignore
+                            consumerMb.Post ConnectionClosed
+                            reader.AdvanceTo consumed
+                        | XCommandReachedEndOfTopic cmd ->
+                            let consumerMb = consumers.[%cmd.ConsumerId]
+                            consumerMb.Post ReachedEndOfTheTopic
+                            reader.AdvanceTo consumed
+                        | XCommandGetTopicsOfNamespaceResponse cmd ->
+                            let result = TopicsOfNamespace { Topics = List.ofSeq cmd.Topics }
+                            handleRespone %cmd.RequestId result reader consumed
+                        | XCommandError cmd ->
+                            Log.Logger.LogError("Error: {0}. Message: {1}", cmd.Error, cmd.Message)
+                            let result = Error
+                            handleRespone %cmd.RequestId result reader consumed
             Log.Logger.LogDebug("[{0}] Finished read socket for {1}", readerId, broker)
         }
 


### PR DESCRIPTION
Splitted valid and invalid command DU cases

Removed try/catch from parsing function because:
1. catched exception is thrown later
2. exception context would be lost, because it is not `reraise` aka C#'s `throw;`, 