### PR TITLE
+added stack-based murmur3 hash calculation

### DIFF
--- a/src/Pulsar.Client.Proto/MurmurHash3.cs
+++ b/src/Pulsar.Client.Proto/MurmurHash3.cs
@@ -9,11 +9,116 @@ namespace Pulsar.Client.Common
 
     public static class MurmurHash3
     {
+        //maximum allowed stackalloc size.
+        const int MaximumStackAllocSize = 32 * 1024;
+
         public static int Hash(string value)
+        {
+            int maxBytesCount = value.Length * sizeof(char);
+
+            //fallback to default hash heap calculation when input string is too long.
+            if (maxBytesCount > MaximumStackAllocSize)
+                return HashWithAllocs(value);
+
+            Span<byte> bytes = stackalloc byte[maxBytesCount];
+            int bytesCount = 0;
+#if NETSTANDARD2_1
+            bytesCount = Encoding.UTF8.GetBytes(value.AsSpan(),bytes); 
+            return Hash(bytes, bytesCount, 0) & Int32.MaxValue;
+#else
+            unsafe
+            {
+                fixed (char* inputChars = value)
+                {
+                    fixed (byte* fixedBytes = &bytes.GetPinnableReference())
+                    {
+                        if (value.Length > 0)
+                            bytesCount = Encoding.UTF8.GetBytes(inputChars, value.Length, fixedBytes, bytes.Length);
+                        return Hash(bytes, bytesCount, 0) & Int32.MaxValue;
+                    }
+                }
+            }
+#endif
+        }
+        public static int HashWithAllocs(string value)
         {
             byte[] input = Encoding.UTF8.GetBytes(value);
             using (var stream = new MemoryStream(input))
                 return Hash(stream, 0) & Int32.MaxValue;
+        }
+
+        //length is required as allocated buffer may be too big for actual values written to it.
+        public static int Hash(Span<byte> bytes, int length, uint seed)
+        {
+            const uint c1 = 0xcc9e2d51;
+            const uint c2 = 0x1b873593;
+
+            uint h1 = seed;
+            uint k1 = 0;
+            uint parsedLength = 0;
+
+            while (parsedLength < length)
+            {
+                Span<byte> chunk = bytes.Slice((int)parsedLength, Math.Min(length - (int)parsedLength,4));
+                parsedLength += (uint)chunk.Length;
+
+                switch (chunk.Length)
+                {
+                    case 4:
+                        /* Get four bytes from the input into an uint */
+                        k1 = (uint)
+                           (chunk[0]
+                          | chunk[1] << 8
+                          | chunk[2] << 16
+                          | chunk[3] << 24);
+
+                        /* bitmagic hash */
+                        k1 *= c1;
+                        k1 = rotl32(k1, 15);
+                        k1 *= c2;
+
+                        h1 ^= k1;
+                        h1 = rotl32(h1, 13);
+                        h1 = h1 * 5 + 0xe6546b64;
+                        break;
+                    case 3:
+                        k1 = (uint)
+                           (chunk[0]
+                          | chunk[1] << 8
+                          | chunk[2] << 16);
+                        k1 *= c1;
+                        k1 = rotl32(k1, 15);
+                        k1 *= c2;
+                        h1 ^= k1;
+                        break;
+                    case 2:
+                        k1 = (uint)
+                           (chunk[0]
+                          | chunk[1] << 8);
+                        k1 *= c1;
+                        k1 = rotl32(k1, 15);
+                        k1 *= c2;
+                        h1 ^= k1;
+                        break;
+                    case 1:
+                        k1 = (uint)(chunk[0]);
+                        k1 *= c1;
+                        k1 = rotl32(k1, 15);
+                        k1 *= c2;
+                        h1 ^= k1;
+                        break;
+
+                }
+            }
+
+            // finalization, magic chants to wrap it all up
+            h1 ^= parsedLength;
+            h1 = fmix(h1);
+
+            unchecked //ignore overflow
+            {
+                return (int)h1;
+            }
         }
 
         public static int Hash(Stream stream, uint seed)


### PR DESCRIPTION
|       Method | Length |       Mean |    Error |   StdDev |     Median |
|------------- |------- |-----------:|---------:|---------:|-----------:|
|  **Murmur3Heap** |      **1** |   **201.6 ms** |  **3.93 ms** |  **5.88 ms** |   **201.8 ms** |
| Murmur3Stack |      1 |   185.2 ms |  3.70 ms |  3.28 ms |   185.0 ms |
|  **Murmur3Heap** |     **10** |   **227.9 ms** |  **6.86 ms** | **19.68 ms** |   **220.6 ms** |
| Murmur3Stack |     10 |   200.8 ms |  4.00 ms |  5.99 ms |   199.5 ms |
|  **Murmur3Heap** |    **100** |   **342.8 ms** |  **6.85 ms** | **19.53 ms** |   **340.3 ms** |
| Murmur3Stack |    100 |   303.6 ms |  7.00 ms | 20.09 ms |   300.4 ms |
|  **Murmur3Heap** |    **500** |   **796.2 ms** | **16.17 ms** | **20.45 ms** |   **791.5 ms** |
| Murmur3Stack |    500 |   642.3 ms | 12.11 ms | 10.74 ms |   645.3 ms |
|  **Murmur3Heap** |   **1000** | **1,375.6 ms** | **20.99 ms** | **19.63 ms** | **1,377.8 ms** |
| Murmur3Stack |   1000 | 1,092.8 ms | 11.04 ms |  9.22 ms | 1,091.5 ms |


