### PR TITLE
Close #93: generate and publish XML documentation into the package

### DIFF
--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -19,6 +19,7 @@
     <Authors>F# community</Authors>
     <PackageVersion>0.18.3</PackageVersion>
     <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Optional: Declare that the Repository URL can be published to NuSpec -->


### PR DESCRIPTION
I've tried to embed xmldoc from the C# project as well, but wasn't successful in that endeavour. It requires too much MSBuild magic I don't have right now.