### PR TITLE
Check reading in startMessageIdInclusive mode

### DIFF
--- a/tests/IntegrationTests/Reader.fs
+++ b/tests/IntegrationTests/Reader.fs
@@ -212,4 +212,33 @@ let tests =
             Expect.equal "" 3 result.Count
             Log.Debug("Finished StartMessageFromRollbackDuration")
         }
+
+        testAsync "Check reading in startMessageIdInclusive mode" {
+            Log.Debug("Started Check reading in startMessageIdInclusive mode")
+            let client = getClient()
+            let topicName = "public/retention/" + Guid.NewGuid().ToString("N")
+            let producerName = "startMessageIdInclusiveProducer"
+            let readerName = "startMessageIdInclusiveReader"
+
+            let! producer =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .ProducerName(producerName)
+                    .EnableBatching(true)
+                    .CreateAsync() |> Async.AwaitTask
+
+            let! messageId = producer.SendAsync("Hello world1" |> Encoding.UTF8.GetBytes) |> Async.AwaitTask
+
+            let! reader =
+                client.NewReader()
+                    .Topic(topicName)
+                    .ReaderName(readerName)
+                    .StartMessageIdInclusive(true)
+                    .StartMessageId(messageId)
+                    .CreateAsync() |> Async.AwaitTask
+
+            let! result = readerLoopRead reader |> Async.AwaitTask
+            Expect.equal "" 1 result.Count
+            Log.Debug("Finished Check reading in startMessageIdInclusive mode")
+        }
     ]


### PR DESCRIPTION
Adds an integration test to reproduce issue https://github.com/fsharplang-ru/pulsar-client-dotnet/issues/134#issuecomment-745252980

The new test fails when I run it locally, but succeeds with this hack fix applied https://github.com/TjeuKayim/pulsar-client-dotnet/commit/6edd70d8b8ea31c5819e0617156b1a71017ca1f7.

```
dotnet run --filter "Reader"
[10:45:09 INF] EXPECTO? Running tests... <Expecto>
[10:45:11 ERR] Reader.Check reading in startMessageIdInclusive mode failed in 00:00:01.7490000.
.
expected: 1
  actual: 0
   at Pulsar.Client.IntegrationTests.Reader.tests@241-90.Invoke(List`1 _arg47) in C:\Users\KayimT\source\pulsar-client-dotnet\tests\IntegrationTests\Reader.fs:line 241
   at Microsoft.FSharp.Control.AsyncPrimitives.CallThenInvokeNoHijackCheck[a,b](AsyncActivation`1 ctxt, FSharpFunc`2 userCode, b result1) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 405
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in F:\workspace\_work\1\s\src\fsharp\FSharp.Core\async.fs:line 105 <Expecto>
[10:45:12 INF] EXPECTO! 8 tests run in 00:00:03.2400196 for Reader - 7 passed, 0 ignored, 1 failed, 0 errored.  <Expecto>
```