### PR TITLE
Remove redundant `dotnet paket install` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Features list (from https://github.com/apache/pulsar/wiki/Client-Features-Matrix
 
  - Fork and clone locally
  - Install dotnet tools: `dotnet tool restore`
- - Install packages: `dotnet paket install`
  - Restore packages: `dotnet restore`
  
 #### MacOS steps before building:


### PR DESCRIPTION
`paket install` is only needed when there're changes to `paket.dependencies` that need to be reflected in `paket.lock` ([docs](https://fsprojects.github.io/Paket/learn-how-to-use-paket.html#Important-paket-commands)).
For restoring locked dependencies `dotnet restore` is sufficient (it executes `paket restore` internally).