### PR TITLE
Exposed redelivery count of the internal msg to the public contract.

### DIFF
--- a/src/Pulsar.Client/Common/DTO.fs
+++ b/src/Pulsar.Client/Common/DTO.fs
@@ -260,6 +260,7 @@ type Message<'T> internal (messageId: MessageId, data: byte[], key: PartitionKey
                   properties: IReadOnlyDictionary<string, string>, encryptionCtx: EncryptionContext option,
                   schemaVersion: byte[], sequenceId: SequenceId, orderingKey: byte[], publishTime: TimeStamp,
                   eventTime: Nullable<TimeStamp>,
+                  redeliveryCount: uint32, 
                   getValue: unit -> 'T) =
     /// Get the unique message ID associated with this message.
     member this.MessageId = messageId
@@ -284,25 +285,27 @@ type Message<'T> internal (messageId: MessageId, data: byte[], key: PartitionKey
     member this.PublishTime = publishTime
     /// Get the event time of the message as Unix timestamp (manually set by the application on produce).
     member this.EventTime = eventTime
+    /// Get the redelivery count of the message
+    member this.RedeliveryCount = redeliveryCount
     /// Get the de-serialized value of the message, according the configured Schema.
     member this.GetValue() =
         getValue()
 
     member internal this.WithMessageId messageId =
         Message(messageId, data, key, hasBase64EncodedKey, properties, encryptionCtx, schemaVersion, sequenceId,
-                orderingKey, publishTime, eventTime, getValue)
+                orderingKey, publishTime, eventTime, redeliveryCount, getValue)
     /// Get a new instance of the message with updated data
     member this.WithData data =
         Message(messageId, data, key, hasBase64EncodedKey, properties, encryptionCtx, schemaVersion, sequenceId,
-                orderingKey, publishTime, eventTime, getValue)
+                orderingKey, publishTime, eventTime, redeliveryCount, getValue)
     /// Get a new instance of the message with updated key
     member this.WithKey (key, hasBase64EncodedKey) =
         Message(messageId, data, key, hasBase64EncodedKey, properties, encryptionCtx, schemaVersion, sequenceId,
-                orderingKey, publishTime, eventTime, getValue)
+                orderingKey, publishTime, eventTime, redeliveryCount, getValue)
     /// Get a new instance of the message with updated properties
     member this.WithProperties properties =
         Message(messageId, data, key, hasBase64EncodedKey, properties, encryptionCtx, schemaVersion, sequenceId,
-                orderingKey, publishTime, eventTime, getValue)
+                orderingKey, publishTime, eventTime, redeliveryCount, getValue)
 
 type Messages<'T> internal(maxNumberOfMessages: int, maxSizeOfMessages: int64) =
 

--- a/src/Pulsar.Client/Common/DTO.fs
+++ b/src/Pulsar.Client/Common/DTO.fs
@@ -260,7 +260,7 @@ type Message<'T> internal (messageId: MessageId, data: byte[], key: PartitionKey
                   properties: IReadOnlyDictionary<string, string>, encryptionCtx: EncryptionContext option,
                   schemaVersion: byte[], sequenceId: SequenceId, orderingKey: byte[], publishTime: TimeStamp,
                   eventTime: Nullable<TimeStamp>,
-                  redeliveryCount: uint32, 
+                  redeliveryCount: int32, 
                   getValue: unit -> 'T) =
     /// Get the unique message ID associated with this message.
     member this.MessageId = messageId

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -679,6 +679,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             rawMessage.Metadata.OrderingKey,
                             rawMessage.Metadata.PublishTime,
                             rawMessage.Metadata.EventTime,
+                            rawMessage.RedeliveryCount,
                             getValue
                         )
             if (rawMessage.RedeliveryCount >= deadLettersProcessor.MaxRedeliveryCount) then
@@ -1348,6 +1349,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                                 singleMessageMetadata.OrderingKey,
                                 rawMessage.Metadata.PublishTime,
                                 eventTime,
+                                rawMessage.RedeliveryCount,
                                 getValue
                             )
                 if (rawMessage.RedeliveryCount >= deadLettersProcessor.MaxRedeliveryCount) then

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -679,7 +679,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             rawMessage.Metadata.OrderingKey,
                             rawMessage.Metadata.PublishTime,
                             rawMessage.Metadata.EventTime,
-                            rawMessage.RedeliveryCount,
+                            (int32 rawMessage.RedeliveryCount),
                             getValue
                         )
             if (rawMessage.RedeliveryCount >= deadLettersProcessor.MaxRedeliveryCount) then
@@ -1349,7 +1349,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                                 singleMessageMetadata.OrderingKey,
                                 rawMessage.Metadata.PublishTime,
                                 eventTime,
-                                rawMessage.RedeliveryCount,
+                                (int32 rawMessage.RedeliveryCount),
                                 getValue
                             )
                 if (rawMessage.RedeliveryCount >= deadLettersProcessor.MaxRedeliveryCount) then


### PR DESCRIPTION
I didnt feel the need to write tests for that, but if you want I will add some. (Tested this locally and it works as expected in both scenarios - negatively acknowledging and acknowledge timeout.

```csharp
8/25/2021 9:38:51 AM Input: 1125, Redelivery count: 0
8/25/2021 9:38:56 AM Input: 1125, Redelivery count: 1
8/25/2021 9:39:01 AM Input: 1125, Redelivery count: 2
8/25/2021 9:39:06 AM Input: 1125, Redelivery count: 3
8/25/2021 9:39:11 AM Input: 1125, Redelivery count: 4
8/25/2021 9:39:16 AM Input: 1125, Redelivery count: 5
8/25/2021 9:39:21 AM Input: 1125, Redelivery count: 6
```

RedeliveryCount is already exposed in java client
https://github.com/apache/pulsar/blob/master/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java#L737