### PR TITLE
Add multi-version support for AutoConsumeSchema.

### DIFF
--- a/src/Pulsar.Client/Api/ISchema.fs
+++ b/src/Pulsar.Client/Api/ISchema.fs
@@ -8,8 +8,8 @@ type ISchema<'T>() =
     abstract member SchemaInfo: SchemaInfo
     abstract member Encode: 'T -> byte[]
     abstract member Decode: byte[] -> 'T
-    abstract member GetSpecificSchema: SchemaInfo -> SchemaVersion option -> ISchema<'T>
-    default this.GetSpecificSchema _ _ =
+    abstract member GetSpecificSchema: SchemaInfo * SchemaVersion option -> ISchema<'T>
+    default this.GetSpecificSchema (_, _) =
         this
     abstract member SupportSchemaVersioning: bool
     default this.SupportSchemaVersioning = false

--- a/src/Pulsar.Client/Api/ISchema.fs
+++ b/src/Pulsar.Client/Api/ISchema.fs
@@ -8,8 +8,8 @@ type ISchema<'T>() =
     abstract member SchemaInfo: SchemaInfo
     abstract member Encode: 'T -> byte[]
     abstract member Decode: byte[] -> 'T
-    abstract member GetSpecificSchema: string -> ISchema<'T>
-    default this.GetSpecificSchema _ =
+    abstract member GetSpecificSchema: SchemaInfo -> SchemaVersion option -> ISchema<'T>
+    default this.GetSpecificSchema _ _ =
         this
     abstract member SupportSchemaVersioning: bool
     default this.SupportSchemaVersioning = false

--- a/src/Pulsar.Client/Schema/AutoConsumeSchema.fs
+++ b/src/Pulsar.Client/Schema/AutoConsumeSchema.fs
@@ -8,3 +8,4 @@ type internal AutoConsumeSchemaStub() =
     override this.SchemaInfo = { Name = "AutoConsume"; Type = SchemaType.AUTO_CONSUME; Schema = [||]; Properties = Map.empty }
     override this.Encode _ = raise <| SchemaSerializationException "AutoConsumeSchema is just stub!"
     override this.Decode _ = raise <| SchemaSerializationException "AutoConsumeSchema is just stub!"
+    override this.SupportSchemaVersioning = true

--- a/src/Pulsar.Client/Schema/AvroSchema.fs
+++ b/src/Pulsar.Client/Schema/AvroSchema.fs
@@ -49,7 +49,7 @@ type internal AvroSchema<'T> private (schema: Schema, avroReader: DatumReader<'T
     override this.Decode bytes =
         use stream = new MemoryStream(bytes)
         avroReader.Read(defaultValue, BinaryDecoder(stream))
-    override this.GetSpecificSchema schemaInfo _ =
+    override this.GetSpecificSchema (schemaInfo, _) =
         let writtenSchema = Schema.Parse(schemaInfo.Schema |> Encoding.UTF8.GetString)
         if avroReader :? SpecificDatumReader<'T> then
             AvroSchema(schema, SpecificDatumReader(writtenSchema, schema), avroWriter) :> ISchema<'T>
@@ -93,5 +93,5 @@ type internal GenericAvroSchema(schemaInfo: SchemaInfo, schemaVersion: SchemaVer
             |> Option.toObj
         GenericRecord(schemaVersionBytes, fields)
         
-    override this.GetSpecificSchema schemaInfo schemaVersion =
+    override this.GetSpecificSchema (schemaInfo, schemaVersion) =
         GenericAvroSchema(schemaInfo,schemaVersion) :> ISchema<_>

--- a/src/Pulsar.Client/Schema/MultiVersionSchemaInfoProvider.fs
+++ b/src/Pulsar.Client/Schema/MultiVersionSchemaInfoProvider.fs
@@ -18,7 +18,7 @@ type internal MultiVersionSchemaInfoProvider(getSchema : (SchemaVersion -> Task<
                 cacheIntry.AbsoluteExpirationRelativeToNow <- Nullable <| TimeSpan.FromMinutes(30.0)
                 cacheIntry.Size <- Nullable(1L)
                 let! schemaReponse = getSchema schemaVersion
-                return schemaReponse |> Option.map (fun sch -> latestSchema.GetSpecificSchema(sch.SchemaInfo.Schema |> Encoding.UTF8.GetString))
+                return schemaReponse |> Option.map (fun sch -> latestSchema.GetSpecificSchema sch.SchemaInfo sch.SchemaVersion )
             })
         
     member this.Close() =

--- a/src/Pulsar.Client/Schema/MultiVersionSchemaInfoProvider.fs
+++ b/src/Pulsar.Client/Schema/MultiVersionSchemaInfoProvider.fs
@@ -18,7 +18,7 @@ type internal MultiVersionSchemaInfoProvider(getSchema : (SchemaVersion -> Task<
                 cacheIntry.AbsoluteExpirationRelativeToNow <- Nullable <| TimeSpan.FromMinutes(30.0)
                 cacheIntry.Size <- Nullable(1L)
                 let! schemaReponse = getSchema schemaVersion
-                return schemaReponse |> Option.map (fun sch -> latestSchema.GetSpecificSchema sch.SchemaInfo sch.SchemaVersion )
+                return schemaReponse |> Option.map (fun sch -> latestSchema.GetSpecificSchema(sch.SchemaInfo, sch.SchemaVersion))
             })
         
     member this.Close() =


### PR DESCRIPTION
### Motivation
Currently, AutoConsumeSchema does not support multi-version schema. This will cause each message to be decoded with the latest schema, instead of getting the correct version schema based on the schemaVersion of the message. This eventually leads to unexpected errors when decoding data.

This PR adds multi-version support for AutoConsumeSchema. 

### Modification
* Set AutoConsumeSchema. SupportSchemaVersioning to true.
* Change the function `ISchema.GetSpecificSchema ` so that we can pass both `SchemaVersion` and `SchemaInfo` to the GenericAvroSchema.
* Override GenericAvroSchema.GetSpecificSchema so that we can use the correct schema version of GenericAvroSchema.