### PR TITLE
Update AvroSchemaGenerator to 2.3

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -8,7 +8,7 @@ NUGET
       System.Reflection (>= 4.3)
       System.Reflection.Emit.ILGeneration (>= 4.7)
       System.Reflection.Emit.Lightweight (>= 4.7)
-    AvroSchemaGenerator (1.9)
+    AvroSchemaGenerator (2.3)
       System.ComponentModel.Annotations (>= 5.0)
       System.Text.Json (>= 5.0.2)
     DerConverter (3.0.0.82)


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Summary

The `AvroSchemaGenerator@1.9` doesn't check the type.Namespace, when type.Namespace is null, the generated schema is incorrect, so I made a PR: https://github.com/eaba/AvroSchemaGenerator/pull/22 to fix this issue, this patch has been released in `AvroSchemaGenerator@2.3`.
