### PR TITLE
Add Wellknown data type support for ProtobufNativeSchema

### DIFF
--- a/src/Pulsar.Client/Schema/ProtobufNativeSchema.fs
+++ b/src/Pulsar.Client/Schema/ProtobufNativeSchema.fs
@@ -20,11 +20,34 @@ type   ProtobufNativeSchemaData(fileDescriptorSet:byte[],
     member  this.rootMessageTypeName =rootMessageTypeName     
     member  this.rootFileDescriptorName =rootFileDescriptorName
 type VirtualFile(content:string)=
+    let timestampProtoName = "/google/protobuf/timestamp.proto"
+    let timestampProtoContent = "
+syntax = \"proto3\";
+
+package google.protobuf;
+
+option csharp_namespace = \"Google.Protobuf.WellKnownTypes\";
+option cc_enable_arenas = true;
+option go_package = \"google.golang.org/protobuf/types/known/timestamppb\";
+option java_package = \"com.google.protobuf\";
+option java_outer_classname = \"TimestampProto\";
+option java_multiple_files = true;
+option objc_class_prefix = \"GPB\";
+
+message Timestamp {
+  int64 seconds = 1;
+  int32 nanos = 2;
+}
+"
     member private this.Content = content
     interface IFileSystem with
         member this.Exists _ = true
-        member this.OpenText _ =
-            new StringReader(this.Content) :> TextReader
+        member this.OpenText path =
+            if timestampProtoName.Equals(path)
+            then
+                new StringReader(timestampProtoContent) :> TextReader
+            else
+                new StringReader(this.Content) :> TextReader
 type internal ProtoBufNativeSchema<'T > () =
     inherit ISchema<'T>()    
   

--- a/src/Pulsar.Client/Schema/ProtobufNativeSchema.fs
+++ b/src/Pulsar.Client/Schema/ProtobufNativeSchema.fs
@@ -3,6 +3,7 @@
 
 open System
 open System.IO
+open System.Reflection
 open System.Text
 open System.Text.Json
 open Google.Protobuf.Reflection
@@ -19,35 +20,26 @@ type   ProtobufNativeSchemaData(fileDescriptorSet:byte[],
     member this.fileDescriptorSet = fileDescriptorSet       
     member  this.rootMessageTypeName =rootMessageTypeName     
     member  this.rootFileDescriptorName =rootFileDescriptorName
-type VirtualFile(content:string)=
-    let timestampProtoName = "/google/protobuf/timestamp.proto"
-    let timestampProtoContent = "
-syntax = \"proto3\";
-
-package google.protobuf;
-
-option csharp_namespace = \"Google.Protobuf.WellKnownTypes\";
-option cc_enable_arenas = true;
-option go_package = \"google.golang.org/protobuf/types/known/timestamppb\";
-option java_package = \"com.google.protobuf\";
-option java_outer_classname = \"TimestampProto\";
-option java_multiple_files = true;
-option objc_class_prefix = \"GPB\";
-
-message Timestamp {
-  int64 seconds = 1;
-  int32 nanos = 2;
-}
-"
+type VirtualFile(fileName:string, content:string)=
+    let assembly = Assembly.GetAssembly typeof<IFileSystem>
+    let resourceNamesList = (assembly.GetManifestResourceNames() |> Array.toList)
     member private this.Content = content
+    member private this.isUserFile(path : String) =
+        // we need to subtract the prefix `/` here.
+        path.Substring(1) |> fileName.Equals
+    member private this.getBuiltinProtoPath(path : String) =
+        $"ProtoBuf{path.Replace('/', '.')}"
     interface IFileSystem with
-        member this.Exists _ = true
+        member this.Exists path =
+            this.isUserFile path ||
+            List.contains (path |> this.getBuiltinProtoPath) resourceNamesList
         member this.OpenText path =
-            if timestampProtoName.Equals(path)
+            if this.isUserFile path
             then
-                new StringReader(timestampProtoContent) :> TextReader
-            else
                 new StringReader(this.Content) :> TextReader
+            else
+                new StreamReader(path |> this.getBuiltinProtoPath |> assembly.GetManifestResourceStream) :> TextReader
+                
 type internal ProtoBufNativeSchema<'T > () =
     inherit ISchema<'T>()    
   
@@ -65,9 +57,9 @@ type internal ProtoBufNativeSchema<'T > () =
                 let userClassNamespace = typeof<'T>.Namespace
                 let userClassName = typeof<'T>.Name               
                
-                let protoForType = Serializer.GetProto<'T> () 
-                let set = FileDescriptorSet( FileSystem = VirtualFile(protoForType))
+                let protoForType = Serializer.GetProto<'T> ()
                 let protoFileName = userClassName + ".proto"
+                let set = FileDescriptorSet( FileSystem = VirtualFile(protoFileName, protoForType))
                 let baseUri =  Uri("file://" + protoFileName, UriKind.Absolute)
                 set.AddImportPath(baseUri.AbsolutePath)
                 set.Add protoFileName |> ignore

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -31,7 +31,7 @@ type AvroSchemaTest = { X: string; Y: ResizeArray<int> }
 type ProtobufNativeSchemaTest = {
         [<ProtoMember(1)>]foo: string
         [<ProtoMember(2)>]bar: double
-        [<ProtoMember(3)>]time: DateTime
+        [<ProtoMember(3)>][<CompatibilityLevel(CompatibilityLevel.Level300)>]time: DateTime
     }
 
 [<Tests>]

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -31,6 +31,7 @@ type AvroSchemaTest = { X: string; Y: ResizeArray<int> }
 type ProtobufNativeSchemaTest = {
         [<ProtoMember(1)>]foo: string
         [<ProtoMember(2)>]bar: double
+        [<ProtoMember(3)>]time: DateTime
     }
 
 [<Tests>]
@@ -194,7 +195,7 @@ let tests =
         }
         
         test "Protobuf native" {
-            let inputs = [{ ProtobufNativeSchemaTest.foo = "X1"; bar = 1.0}]
+            let inputs = [{ ProtobufNativeSchemaTest.foo = "X1"; bar = 1.0; time = DateTime.Now}]
             for input in inputs do
                 let schema = Schema.PROTOBUF_NATIVE<ProtobufNativeSchemaTest>()
                 let output =
@@ -203,6 +204,7 @@ let tests =
                     |> schema.Decode
                 Expect.equal "" input.foo output.foo
                 Expect.equal "" input.bar output.bar
+                Expect.equal "" input.time output.time
         }
         
         test "Avro schema works fine with Avro generated classes" {


### PR DESCRIPTION
This fixes #194 

Currently, ProtobufNativeSchema does not support handling data with builtin well-known type like DateTime. This PR will add Wellknown type(include `System.DateTime`, `System.TimeSpan`, `System.Guid`and `System.Decimal`) support for ProtobufNativeSchema. 

> Currently, this PR is only a preliminary change, the specific implementation solution still needs to be discussed. I am wondering if there is a better solution so that we don't need to introduce the content of proto files(such as `/google/protobuf/timestamp.proto`) in our project. Any ideas on this ? @Lanayx  Thanks!

Updated: This PR is ready for review.