### PR TITLE
Fix incompatible path in macOS/Linux.

### DIFF
--- a/tests/AvroGenerated/Generator.cs
+++ b/tests/AvroGenerated/Generator.cs
@@ -8,7 +8,7 @@ namespace AvroGenerated
     {
         private static void Main(string[] args)
         {
-            string[] allLines = File.ReadAllLines(@"..\..\..\sample.avsc", Encoding.UTF8);
+            string[] allLines = File.ReadAllLines(@"../../../sample.avsc", Encoding.UTF8);
 
             var schemaJson = string.Join("", allLines);
 
@@ -16,7 +16,7 @@ namespace AvroGenerated
             var codeGen = new CodeGen();
             codeGen.AddSchema(avroSchema);
             codeGen.GenerateCode();
-            codeGen.WriteTypes(@"..\..\..\..\");    
+            codeGen.WriteTypes(@"../../../../");    
         }
         
     }

--- a/tests/ProtobufNativeGenerated/Generator.cs
+++ b/tests/ProtobufNativeGenerated/Generator.cs
@@ -34,14 +34,14 @@ namespace ProtobufNativeGenerated
         static void Main(string[] args)
         {
             CodeGenerator codegen = CSharpCodeGenerator.Default;
-            var set = new FileDescriptorSet{FileSystem = new VirtualFile(@"..\..\..\sample.proto")};
+            var set = new FileDescriptorSet{FileSystem = new VirtualFile(@"../../../sample.proto")};
             var protoFileName = "sample.proto"; //https://developers.google.com/protocol-buffers/docs/proto3
             var baseUri = new Uri("file://" + protoFileName, UriKind.Absolute);
             set.AddImportPath(baseUri.AbsolutePath);
             set.Add(protoFileName);
             set.Process();
             var files = codegen.Generate(set);
-            WriteFiles(files, @"..\..\..\");
+            WriteFiles(files, @"../../../");
           
         }
         static void WriteFiles(IEnumerable<CodeFile> files, string outPath)


### PR DESCRIPTION
There are some paths in the code that are not compatible with no-windows systems(macOS/Linux).
When running these programs, the FileNotFoundException will be thrown. This PR fixes this issue.
