### PR TITLE
Replace testAsync to testTask in unit and integration tests

### DIFF
--- a/tests/IntegrationTests/BackPressure.fs
+++ b/tests/IntegrationTests/BackPressure.fs
@@ -3,6 +3,7 @@ module Pulsar.Client.IntegrationTests.BackPressure
 open Expecto
 open Expecto.Flip
 open Pulsar.Client.Api
+open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 open System.Threading.Tasks
 open System
@@ -12,16 +13,17 @@ let tests =
 
     testList "Backpressure" [
 
-        testAsync "Default backpressure throws" {
+        testTask "Default backpressure throws" {
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .EnableBatching(false)
                     .MaxPendingMessages(1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync()
+                    
             Expect.throwsT2<ProducerQueueIsFullError> (fun () ->
                     [| producer.SendAsync([|0uy|]); producer.SendAsync([|1uy|]) |]
                     |> Task.WhenAll
@@ -30,16 +32,17 @@ let tests =
                 |> ignore
         }
         
-        testAsync "Default backpressure throws for sendandforget" {
+        testTask "Default backpressure throws for sendandforget" {
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .EnableBatching(false)
                     .MaxPendingMessages(1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync()
+                    
             Expect.throwsT2<ProducerQueueIsFullError> (fun () ->
                     [| producer.SendAndForgetAsync([|0uy|]); producer.SendAndForgetAsync([|1uy|]) |]
                     |> Task.WhenAll
@@ -48,40 +51,42 @@ let tests =
                 |> ignore
         }
         
-        testAsync "Blocking backpressure doesn't throw" {
+        testTask "Blocking backpressure doesn't throw" {
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .EnableBatching(false)
                     .BlockIfQueueFull(true)
                     .MaxPendingMessages(1)
-                    .CreateAsync() |> Async.AwaitTask
-            let! messageIds =
+                    .CreateAsync()
+                    
+            let! (messageIds : MessageId[]) =
                     [| producer.SendAsync([|0uy|]); producer.SendAsync([|1uy|]); producer.SendAsync([|2uy|]) |]
                     |> Task.WhenAll
-                    |> Async.AwaitTask
+                    
             Expect.isLessThan "" (messageIds.[0], messageIds.[1])
             Expect.isLessThan "" (messageIds.[1], messageIds.[2])
         }
         
-        testAsync "Blocking backpressure doesn't throw for sendAndForget" {
+        testTask "Blocking backpressure doesn't throw for sendAndForget" {
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .EnableBatching(false)
                     .BlockIfQueueFull(true)
                     .MaxPendingMessages(1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync()
+                    
             let! _ =
                     [| producer.SendAndForgetAsync([|0uy|]); producer.SendAndForgetAsync([|1uy|]); producer.SendAndForgetAsync([|2uy|]) |]
                     |> Task.WhenAll
-                    |> Async.AwaitTask
+                    
             ()
         }
     ]

--- a/tests/IntegrationTests/Basic.fs
+++ b/tests/IntegrationTests/Basic.fs
@@ -194,7 +194,7 @@ let tests =
             let producerName = "concurrentProducer"
             let consumerName = "concurrentConsumer"
 
-            let! (producer : IProducer<byte[]>) =
+            let! producer =
                 client.NewProducer()
                     .Topic(topicName)
                     .ProducerName(producerName)
@@ -236,7 +236,7 @@ let tests =
             try
                 do! Task.WhenAll(resultTasks) 
             with
-            | ex when ex.InnerException.GetType() = typeof<AlreadyClosedException> ->
+            | :? AlreadyClosedException ->
                 ()
             | ex ->
                 failtestf "Incorrect exception type %A" (ex.GetType().FullName)

--- a/tests/IntegrationTests/Batching.fs
+++ b/tests/IntegrationTests/Batching.fs
@@ -18,7 +18,7 @@ let tests =
 
     testList "Batching" [
 
-        testAsync "Batch get sended if batch size exceeds" {
+        testTask "Batch get sended if batch size exceeds" {
 
             Log.Debug("Started 'Batch get sended if batch size exceeds'")
 
@@ -31,7 +31,7 @@ let tests =
                     .Topic(topicName)
                     .ConsumerName("batch consumer")
                     .SubscriptionName("batch-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let! producer =
                 client.NewProducer()
@@ -39,16 +39,16 @@ let tests =
                     .ProducerName("batch producer")
                     .EnableBatching(true)
                     .BatchingMaxMessages(messagesNumber)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            do! fastProduceMessages producer messagesNumber "batch producer" |> Async.AwaitTask
-            do! consumeMessages consumer messagesNumber "batch consumer" |> Async.AwaitTask
+            do! fastProduceMessages producer messagesNumber "batch producer" 
+            do! consumeMessages consumer messagesNumber "batch consumer" 
 
             Log.Debug("Finished 'Batch get sended if batch size exceeds'")
 
         }
 
-        testAsync "Batch get sended if timeout exceeds" {
+        testTask "Batch get sended if timeout exceeds" {
 
             Log.Debug("Started 'Batch get sended if timeout exceeds'")
 
@@ -62,7 +62,7 @@ let tests =
                     .Topic(topicName)
                     .ConsumerName("batch consumer")
                     .SubscriptionName("batch-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let! producer =
                 client.NewProducer()
@@ -71,19 +71,19 @@ let tests =
                     .EnableBatching(true)
                     .BatchingMaxMessages(batchSize)
                     .BatchingMaxPublishDelay(TimeSpan.FromMilliseconds(100.0))
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            do! fastProduceMessages producer messagesNumber "batch producer" |> Async.AwaitTask
+            do! fastProduceMessages producer messagesNumber "batch producer" 
 
-            do! Async.Sleep 200
+            do! Task.Delay 200
 
-            do! consumeMessages consumer messagesNumber "batch consumer" |> Async.AwaitTask
+            do! consumeMessages consumer messagesNumber "batch consumer" 
 
             Log.Debug("Finished 'Batch get sended if timeout exceeds'")
 
         }
 
-        testAsync "Batch get created from several tasks" {
+        testTask "Batch get created from several tasks" {
 
             Log.Debug("Started 'Batch get created from several tasks'")
 
@@ -96,7 +96,7 @@ let tests =
                     .Topic(topicName)
                     .ConsumerName("batch consumer")
                     .SubscriptionName("batch-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let! producer =
                 client.NewProducer()
@@ -104,19 +104,19 @@ let tests =
                     .ProducerName("batch producer")
                     .EnableBatching(true)
                     .BatchingMaxMessages(messagesNumber)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let taskData = createSendAndWaitTasks producer messagesNumber "batch producer"
             let tasks = taskData |> Array.map fst
             let sentMessages = taskData |> Array.map snd
 
-            do! tasks |> Task.WhenAll |> Async.AwaitTask
-            do! consumeAndVerifyMessages consumer "batch consumer" sentMessages |> Async.AwaitTask
+            do! tasks |> Task.WhenAll 
+            do! consumeAndVerifyMessages consumer "batch consumer" sentMessages 
 
             Log.Debug("Finished 'Batch get created from several tasks'")
         }
 
-        testAsync "Keys and properties are propertly passed with default batching" {
+        testTask "Keys and properties are propertly passed with default batching" {
 
             Log.Debug("Started Keys and properties are propertly passed with default batching")
             let client = getClient()
@@ -129,14 +129,14 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(true)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName(consumerName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -150,12 +150,12 @@ let tests =
                         do! consumeMessagesWithProps consumer 100 consumerName
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask)
 
             Log.Debug("Finished Keys and properties are propertly passed with default batching")
         }
 
-        testAsync "Keys and properties are propertly passed with key-based batching" {
+        testTask "Keys and properties are propertly passed with key-based batching" {
 
             Log.Debug("Started Keys and properties are propertly passed with key-based batching")
             let client = getClient()
@@ -171,14 +171,14 @@ let tests =
                     .EnableBatching(true)
                     .BatchingMaxPublishDelay(TimeSpan.FromMilliseconds(100.0))
                     .BatchBuilder(BatchBuilder.KeyBased)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName(consumerName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producer1Task =
                 Task.Run(fun () ->
@@ -199,12 +199,11 @@ let tests =
                         do! consumeMessages consumer numberOfMessages consumerName
                     }:> Task)
 
-            do! Task.WhenAll(producer1Task, producer2Task, consumerTask) |> Async.AwaitTask
-
+            do! Task.WhenAll(producer1Task, producer2Task, consumerTask) 
             Log.Debug("Finished Keys and properties are propertly passed with key-based batching")
         }
         
-        testAsync "Batch recieve works with regular consumer"{
+        testTask "Batch recieve works with regular consumer"{
             Log.Debug("Started Batch recieve works with regular consumer")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
@@ -218,15 +217,15 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName(consumerName)
                     .SubscriptionName("test-subscription")
                     .BatchReceivePolicy(BatchReceivePolicy(8, -1L, batchTimeout))
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -270,7 +269,7 @@ let tests =
                                 
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Batch recieve works with regular consumer")
         }

--- a/tests/IntegrationTests/Cancellation.fs
+++ b/tests/IntegrationTests/Cancellation.fs
@@ -18,23 +18,23 @@ let tests =
 
     testList "Cancellation" [
 
-        testAsync "Cancellation without receiving a single message works fine" {
+        testTask "Cancellation without receiving a single message works fine" {
 
             Log.Debug("Started Cancellation without receiving a single message works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let cts = new CancellationTokenSource()
             
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let consumerTask = consumer.ReceiveAsync(cts.Token)
             cts.CancelAfter 100
             try
-                do! consumerTask |> Async.AwaitTask |> Async.Ignore
+                do! consumerTask 
                 failwith "Unexpected success"
             with _ ->
                 Expect.equal "" consumerTask.Status TaskStatus.Canceled
@@ -42,7 +42,7 @@ let tests =
             Log.Debug("Finished Cancellation without receiving a single message works fine")
         }
         
-        testAsync "Cancellation without receiving a single message works fine (multitopic)" {
+        testTask "Cancellation without receiving a single message works fine (multitopic)" {
 
             Log.Debug("Started Cancellation without receiving a single message works fine (multitopic)")
             let client = getClient()            
@@ -50,16 +50,16 @@ let tests =
             let topicName2 = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let cts = new CancellationTokenSource()
             
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topics(seq{topicName1;topicName2})
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let consumerTask = consumer.ReceiveAsync(cts.Token)
             cts.CancelAfter 100
             try
-                do! consumerTask |> Async.AwaitTask |> Async.Ignore
+                do! consumerTask 
                 failwith "Unexpected success"
             with _ ->
                 Expect.equal "" consumerTask.Status TaskStatus.Canceled
@@ -67,7 +67,7 @@ let tests =
             Log.Debug("Finished Cancellation without receiving a single message works fine (multitopic)")
         }        
         
-        testAsync "Cancellation of first of two waiters works fine" {
+        testTask "Cancellation of first of two waiters works fine" {
 
             Log.Debug("Started Cancellation of first of two waiters works fine")
             let client = getClient()
@@ -75,29 +75,29 @@ let tests =
             let cts1 = new CancellationTokenSource()
             let cts2 = new CancellationTokenSource()
             
-            let! producer =
+            let! (producer : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
-            let! consumer =
+            let! (consumer : IConsumer<string>) =
                 client.NewConsumer(Schema.STRING())
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let task1 = consumer.ReceiveAsync(cts1.Token)
             let task2 = consumer.ReceiveAsync(cts2.Token)
             let resultingTask = Task.WhenAll(task1, task2)
             
             cts1.CancelAfter 100
-            do! Async.Sleep 150
+            do! Task.Delay 150
             
             let text = "Hello!"
-            let! _ = producer.SendAsync(text) |> Async.AwaitTask
+            let! _ = producer.SendAsync(text) 
             
             try
-                let! _ = resultingTask |> Async.AwaitTask
+                let! _ = resultingTask 
                 failwith "Unexpected success"
             with _ ->
                 Expect.equal "" TaskStatus.Canceled task1.Status
@@ -107,7 +107,7 @@ let tests =
             Log.Debug("Finished Cancellation of first of two waiters works fine")
         }
         
-        testAsync "Cancellation of first of two waiters works fine (multitopic)" {
+        testTask "Cancellation of first of two waiters works fine (multitopic)" {
 
             Log.Debug("Started Cancellation of first of two waiters works fine (multitopic)")
             let client = getClient()
@@ -116,29 +116,29 @@ let tests =
             let cts1 = new CancellationTokenSource()
             let cts2 = new CancellationTokenSource()
             
-            let! producer =
+            let! (producer : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
-            let! consumer =
+            let! (consumer : IConsumer<string>) =
                 client.NewConsumer(Schema.STRING())
                     .Topics(seq { topicName1; topicName2 })
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let task1 = consumer.ReceiveAsync(cts1.Token)
             let task2 = consumer.ReceiveAsync(cts2.Token)
             let resultingTask = Task.WhenAll(task1, task2)
             
             cts1.CancelAfter 100
-            do! Async.Sleep 150
+            do! Task.Delay 150
             
             let text = "Hello!"
-            let! _ = producer.SendAsync(text) |> Async.AwaitTask
+            let! _ = producer.SendAsync(text) 
             
             try
-                let! _ = resultingTask |> Async.AwaitTask
+                let! _ = resultingTask 
                 failwith "Unexpected success"
             with _ ->
                 Expect.equal "" TaskStatus.Canceled task1.Status
@@ -148,7 +148,7 @@ let tests =
             Log.Debug("Finished Cancellation of first of two waiters works fine (multitopic)")
         }
         
-        testAsync "Cancellation of first of two waiters works fine with batch receive" {
+        testTask "Cancellation of first of two waiters works fine with batch receive" {
 
             Log.Debug("Started Cancellation of first of two waiters works fine with batch receive")
             let client = getClient()
@@ -156,30 +156,30 @@ let tests =
             let cts1 = new CancellationTokenSource()
             let cts2 = new CancellationTokenSource()
             
-            let! producer =
+            let! (producer : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
-            let! consumer =
+            let! (consumer : IConsumer<string>) =
                 client.NewConsumer(Schema.STRING())
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .BatchReceivePolicy(BatchReceivePolicy(2, -1L, TimeSpan.FromHours(1.0)))
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let task1 = consumer.BatchReceiveAsync(cts1.Token)
             let task2 = consumer.BatchReceiveAsync(cts2.Token)
             let resultingTask = Task.WhenAll(task1, task2)
             
-            let! _ = producer.SendAsync("Hello 1") |> Async.AwaitTask
+            let! _ = producer.SendAsync("Hello 1") 
             cts1.CancelAfter 100
-            do! Async.Sleep 150
+            do! Task.Delay 150
             
-            let! _ = producer.SendAsync("Hello 2") |> Async.AwaitTask
+            let! _ = producer.SendAsync("Hello 2") 
             
             try
-                let! _ = resultingTask |> Async.AwaitTask
+                let! _ = resultingTask 
                 failwith "Unexpected success"
             with ex ->
                 Expect.equal "" TaskStatus.Canceled task1.Status
@@ -189,7 +189,7 @@ let tests =
             Log.Debug("Finished Cancellation of first of two waiters works fine with batch receive")
         }
                 
-        testAsync "Cancellation of first of two waiters works fine with batch receive (multitopic)" {
+        testTask "Cancellation of first of two waiters works fine with batch receive (multitopic)" {
 
             Log.Debug("Started Cancellation of first of two waiters works fine with batch receive (multitopic)")
             let client = getClient()
@@ -198,35 +198,35 @@ let tests =
             let cts1 = new CancellationTokenSource()
             let cts2 = new CancellationTokenSource()
             
-            let! producer1 =
+            let! (producer1 : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
                     
-            let! producer2 =
+            let! (producer2 : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName1)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
-            let! consumer =
+            let! (consumer : IConsumer<string>) =
                 client.NewConsumer(Schema.STRING())
                     .Topics(seq { topicName1; topicName2 })
                     .SubscriptionName("test-subscription")
                     .BatchReceivePolicy(BatchReceivePolicy(2, -1L, TimeSpan.FromHours(1.0)))
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let task1 = consumer.BatchReceiveAsync(cts1.Token)
             let task2 = consumer.BatchReceiveAsync(cts2.Token)
             let resultingTask = Task.WhenAll(task1, task2)
             
-            let! _ = producer1.SendAsync("Hello 1") |> Async.AwaitTask
+            let! _ = producer1.SendAsync("Hello 1") 
             cts1.CancelAfter 100
-            do! Async.Sleep 150
+            do! Task.Delay 150
             
-            let! _ = producer2.SendAsync("Hello 2") |> Async.AwaitTask
+            let! _ = producer2.SendAsync("Hello 2") 
             
             try
-                let! _ = resultingTask |> Async.AwaitTask
+                let! _ = resultingTask 
                 failwith "Unexpected success"
             with _ ->
                 Expect.equal "" TaskStatus.Canceled task1.Status

--- a/tests/IntegrationTests/DeadLetters.fs
+++ b/tests/IntegrationTests/DeadLetters.fs
@@ -46,7 +46,7 @@ let tests =
         }
 
     testList "deadLetters" [
-        testAsync "Failed messages stored in a configured dead letter topic" {
+        testTask "Failed messages stored in a configured dead letter topic" {
 
             let description = "Failed messages stored in a configured dead letter topic"
 
@@ -63,7 +63,6 @@ let tests =
                     .Topic(config.TopicName)
                     .EnableBatching(false)
                     .CreateAsync()
-                    |> Async.AwaitTask
 
             let! consumer =
                 createConsumer()
@@ -74,7 +73,6 @@ let tests =
                     .NegativeAckRedeliveryDelay(TimeSpan.FromSeconds(0.5))
                     .DeadLetterPolicy(config.DeadLettersPolicy)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let! dlqConsumer =
                 createConsumer()
@@ -83,8 +81,7 @@ let tests =
                     .SubscriptionName(config.SubscriptionName)
                     .SubscriptionType(SubscriptionType.Shared)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
-
+                    
             let producerTask =
                 Task.Run(fun () ->
                     task {
@@ -110,12 +107,12 @@ let tests =
                     dlqConsumerTask
                 |]
 
-            do! Task.WhenAll(tasks) |> Async.AwaitTask
+            do! Task.WhenAll(tasks) 
 
             description |> logTestEnd
         }
         
-        testAsync "Partitioned topic failed messages stored in a configured dead letter topic" {
+        testTask "Partitioned topic failed messages stored in a configured dead letter topic" {
 
             let description = "Failed messages in a partitioned topic are stored in a configured dead letter topic"
 
@@ -132,7 +129,6 @@ let tests =
                     .Topic(config.TopicName)
                     .EnableBatching(false)
                     .CreateAsync()
-                    |> Async.AwaitTask
 
             let! consumer =
                 createConsumer()
@@ -144,7 +140,6 @@ let tests =
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .DeadLetterPolicy(config.DeadLettersPolicy)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let! dlqConsumer =
                 createConsumer()
@@ -154,7 +149,6 @@ let tests =
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .SubscriptionType(SubscriptionType.Shared)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let messages = generateMessages config.NumberOfMessages producerName
             
@@ -183,13 +177,13 @@ let tests =
                     dlqConsumerTask
                 |]
 
-            do! Task.WhenAll(tasks) |> Async.AwaitTask
-            do! Async.Sleep(110) // wait for acks
+            do! Task.WhenAll(tasks) 
+            do! Task.Delay(110) // wait for acks
 
             description |> logTestEnd
         }
 
-        testAsync "Failed messages stored in a default dead letter topic" {
+        testTask "Failed messages stored in a default dead letter topic" {
 
             let description = "Failed messages stored in a default dead letter topic"
 
@@ -206,7 +200,6 @@ let tests =
                     .Topic(config.TopicName)
                     .EnableBatching(false)
                     .CreateAsync()
-                    |> Async.AwaitTask
 
             let! consumer =
                 createConsumer()
@@ -217,7 +210,6 @@ let tests =
                     .NegativeAckRedeliveryDelay(TimeSpan.FromSeconds(0.5))
                     .DeadLetterPolicy(DeadLetterPolicy(0))
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let! dlqConsumer =
                 createConsumer()
@@ -226,7 +218,6 @@ let tests =
                     .SubscriptionName(config.SubscriptionName)
                     .SubscriptionType(SubscriptionType.Shared)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let producerTask =
                 Task.Run(fun () ->
@@ -253,12 +244,12 @@ let tests =
                     dlqConsumerTask
                 |]
 
-            do! Task.WhenAll(tasks) |> Async.AwaitTask
+            do! Task.WhenAll(tasks) 
 
             description |> logTestEnd
         }
 
-        testAsync "Failed batch stored in a configured default letter topic" {
+        testTask "Failed batch stored in a configured default letter topic" {
 
             let description = "Failed batch stored in a configured dead letter topic"
 
@@ -275,7 +266,6 @@ let tests =
                     .Topic(config.TopicName)
                     .BatchingMaxMessages(config.NumberOfMessages)
                     .CreateAsync()
-                    |> Async.AwaitTask
 
             let! consumer =
                 createConsumer()
@@ -286,7 +276,6 @@ let tests =
                     .NegativeAckRedeliveryDelay(TimeSpan.FromSeconds(0.5))
                     .DeadLetterPolicy(config.DeadLettersPolicy)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let! dlqConsumer =
                 createConsumer()
@@ -295,7 +284,6 @@ let tests =
                     .SubscriptionName(config.SubscriptionName)
                     .SubscriptionType(SubscriptionType.Shared)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let producerTask =
                 Task.Run(fun () ->
@@ -322,12 +310,12 @@ let tests =
                     dlqConsumerTask
                 |]
 
-            do! Task.WhenAll(tasks) |> Async.AwaitTask
+            do! Task.WhenAll(tasks) 
 
             description |> logTestEnd
         }
 
-        testAsync "Some failed batch messages get stored in a configured default letter topic" {
+        testTask "Some failed batch messages get stored in a configured default letter topic" {
 
             let description = "Failed batch stored in a configured dead letter topic"
 
@@ -349,9 +337,8 @@ let tests =
                     .BatchingMaxMessages(config.NumberOfMessages)
                     .BatchingMaxPublishDelay(TimeSpan.FromMilliseconds(100.0))
                     .CreateAsync()
-                    |> Async.AwaitTask
 
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 createConsumer()
                     .ConsumerName(consumerName)
                     .Topic(config.TopicName)
@@ -360,16 +347,14 @@ let tests =
                     .NegativeAckRedeliveryDelay(TimeSpan.FromSeconds(0.5))
                     .DeadLetterPolicy(DeadLetterPolicy(redeliveryCount, config.DeadLettersPolicy.DeadLetterTopic))
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
-            let! dlqConsumer =
+            let! (dlqConsumer : IConsumer<byte[]>) =
                 createConsumer()
                     .ConsumerName(dlqConsumerName)
                     .Topic(config.DeadLettersPolicy.DeadLetterTopic)
                     .SubscriptionName(config.SubscriptionName)
                     .SubscriptionType(SubscriptionType.Shared)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
 
             let producerTask =
                 Task.Run(fun () ->
@@ -413,12 +398,12 @@ let tests =
                     dlqConsumerTask
                 |]
 
-            do! Task.WhenAll(tasks) |> Async.AwaitTask
+            do! Task.WhenAll(tasks) 
 
             description |> logTestEnd
         }
         
-        testAsync "Reconsume later works properly" {
+        testTask "Reconsume later works properly" {
 
             let description = "Reconsume later works properly"
 
@@ -428,27 +413,25 @@ let tests =
             let producerName = "reconsumeProducer"
             let consumerName = "reconsumeConsumer"
 
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 createProducer()
                     .ProducerName(producerName)
                     .Topic(config.TopicName)
                     .EnableBatching(false)
                     .CreateAsync()
-                    |> Async.AwaitTask
 
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 createConsumer()
                     .ConsumerName(consumerName)
                     .Topic(config.TopicName)
                     .SubscriptionName(config.SubscriptionName)
                     .EnableRetry(true)
                     .SubscribeAsync()
-                    |> Async.AwaitTask
          
-            let! msgId = producer.SendAsync([| 0uy; 1uy; 0uy |]) |> Async.AwaitTask
-            let! msg1 = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.ReconsumeLaterAsync(msg1, %(DateTime.UtcNow.AddSeconds(1.0) |> convertToMsTimestamp)) |> Async.AwaitTask
-            let! msg2 = consumer.ReceiveAsync() |> Async.AwaitTask
+            let! msgId = producer.SendAsync([| 0uy; 1uy; 0uy |]) 
+            let! (msg1 : Message<byte[]>) = consumer.ReceiveAsync() 
+            do! consumer.ReconsumeLaterAsync(msg1, %(DateTime.UtcNow.AddSeconds(1.0) |> convertToMsTimestamp)) 
+            let! (msg2 : Message<byte[]>) = consumer.ReceiveAsync() 
 
             Expect.equal "" msgId msg1.MessageId
             Expect.equal "" (msg1.GetValue() |> Array.toList) (msg2.GetValue() |> Array.toList)

--- a/tests/IntegrationTests/Failover.fs
+++ b/tests/IntegrationTests/Failover.fs
@@ -14,7 +14,7 @@ open Serilog
 let tests =
     testList "Failover" [ 
 
-        testAsync "Failover consumer works fine" {
+        testTask "Failover consumer works fine" {
 
             Log.Debug("Started Failover consumer works fine")
             let client = getClient()
@@ -28,7 +28,7 @@ let tests =
                 client.NewProducer()
                     .Topic(topicName)
                     .ProducerName(producerName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer1 =
                 client.NewConsumer()
@@ -36,7 +36,7 @@ let tests =
                     .ConsumerName(consumerName1)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.Failover)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
                     
             let! consumer2 =
                 client.NewConsumer()
@@ -44,7 +44,7 @@ let tests =
                     .ConsumerName(consumerName2)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.Failover)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -66,13 +66,13 @@ let tests =
                         do! consumeMessages consumer2 numberOfMessages consumerName2
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) 
 
             Log.Debug("Finished Failover consumer works fine")
         }
 
         // TODO: uncomment and check in 2.8
-        ptestAsync "Failover consumer with PriorityLevel works fine" {
+        testTask "Failover consumer with PriorityLevel works fine" {
 
             Log.Debug("Started Failover consumer with PriorityLevel works fine")
             let client = getClient()
@@ -91,7 +91,7 @@ let tests =
                     .Topic(topicName)
                     .EnableBatching(false)
                     .ProducerName(producerName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer1 =
                 client.NewConsumer()
@@ -100,7 +100,7 @@ let tests =
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.Failover)
                     .PriorityLevel(consumerPriority1)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
                     
             let! consumer2 =
                 client.NewConsumer()
@@ -109,7 +109,7 @@ let tests =
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.Failover)
                     .PriorityLevel(consumerPriority2)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
                     
             let! consumer3 =
                 client.NewConsumer()
@@ -118,9 +118,9 @@ let tests =
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.Failover)
                     .PriorityLevel(consumerPriority3)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            do! Task.Delay(1000) |> Async.AwaitTask
+            do! Task.Delay(1000) 
             
             let messages1 = generateMessages numberOfMessages (producerName + "1")
             let messages2 = generateMessages numberOfMessages (producerName + "2")
@@ -153,10 +153,10 @@ let tests =
                         do! consumeAndVerifyMessages consumer3 consumerName3 messages2
                     }:> Task)
 
-            let! failoverTask = Task.WhenAny(consumer2Task, consumer3Task) |> Async.AwaitTask
+            let! failoverTask = Task.WhenAny(consumer2Task, consumer3Task) 
             
-            do! Task.WhenAll(producerTask, consumer1Task, failoverTask) |> Async.AwaitTask
-            do! Async.Sleep(110) // wait for acks
+            do! Task.WhenAll(producerTask, consumer1Task, failoverTask) 
+            do! Task.Delay(110) // wait for acks
 
             Log.Debug("Finished Failover consumer with PriorityLevel works fine")
         }

--- a/tests/IntegrationTests/Failover.fs
+++ b/tests/IntegrationTests/Failover.fs
@@ -72,7 +72,7 @@ let tests =
         }
 
         // TODO: uncomment and check in 2.8
-        testTask "Failover consumer with PriorityLevel works fine" {
+        ptestTask "Failover consumer with PriorityLevel works fine" {
 
             Log.Debug("Started Failover consumer with PriorityLevel works fine")
             let client = getClient()

--- a/tests/IntegrationTests/Flow.fs
+++ b/tests/IntegrationTests/Flow.fs
@@ -12,7 +12,7 @@ let tests =
 
     testList "Flow" [
 
-        testAsync "Send and receive 100 messages concurrently works fine with small receiver queue size" {
+        testTask "Send and receive 100 messages concurrently works fine with small receiver queue size" {
 
             Log.Debug("Started Send and receive 100 messages concurrently works fine with small receiver queue size")
             let client = getClient()
@@ -21,14 +21,14 @@ let tests =
             let! producer =
                 client.NewProducer()
                     .Topic(topicName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .ReceiverQueueSize(10)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -42,12 +42,12 @@ let tests =
                         do! consumeMessages consumer 100 ""
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Send and receive 100 messages concurrently works fine with small receiver queue size")
         }
 
-        testAsync "Send and receive 100 messages concurrently works fine with small receiver queue size and no batches" {
+        testTask "Send and receive 100 messages concurrently works fine with small receiver queue size and no batches" {
 
             Log.Debug("Started Send and receive 100 messages concurrently works fine with small receiver queue size and no batches")
             let client = getClient()
@@ -57,14 +57,14 @@ let tests =
                 client.NewProducer()
                     .Topic(topicName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .ReceiverQueueSize(10)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -78,7 +78,7 @@ let tests =
                         do! consumeMessages consumer 100 ""
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Send and receive 100 messages concurrently works fine with small receiver queue size and no batches")
         }

--- a/tests/IntegrationTests/Keys.fs
+++ b/tests/IntegrationTests/Keys.fs
@@ -6,6 +6,7 @@ open Expecto
 open System.Text
 open System.Threading.Tasks
 open FSharp.UMX
+open Pulsar.Client.Api
 open Pulsar.Client.Common
 open Serilog
 open Pulsar.Client.IntegrationTests.Common
@@ -16,7 +17,7 @@ let tests =
 
     testList "Keys" [
 
-        testAsync "Keys and properties are propertly passed" {
+        testTask "Keys and properties are propertly passed" {
 
             Log.Debug("Started Keys and properties are propertly passed")
             let client = getClient()
@@ -30,14 +31,14 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName(consumerName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -51,12 +52,12 @@ let tests =
                         do! consumeMessagesWithProps consumer numMessages consumerName
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Keys and properties are propertly passed")
         }
 
-        testAsync "Messages with same key always go to the same consumer" {
+        testTask "Messages with same key always go to the same consumer" {
 
             Log.Debug("Started Messages with same key always go to the same consumer")
             let client = getClient()
@@ -65,30 +66,30 @@ let tests =
             let consumerName2 = "PartitionedConsumer2"
             let producerName = "PartitionedProducer"
 
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer1 =
+            let! (consumer1 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName1)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            let! consumer2 =
+            let! (consumer2 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName2)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -146,12 +147,12 @@ let tests =
                         Log.Debug("consumer2Task finished")
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task)
 
             Log.Debug("Finished Messages with same key always go to the same consumer")
         }
 
-        testAsync "Messages with same key always go to the same consumer, when KeyBased batching is enabled" {
+        testTask "Messages with same key always go to the same consumer, when KeyBased batching is enabled" {
 
             Log.Debug("Started Messages with same key always go to the same consumer, when KeyBased batching is enabled")
             let client = getClient()
@@ -160,32 +161,32 @@ let tests =
             let consumerName2 = "BatchedPartitionedConsumer2"
             let producerName = "BatchedPartitionedProducer"
 
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .BatchBuilder(BatchBuilder.KeyBased)
                     .BatchingMaxPublishDelay(TimeSpan.FromMilliseconds(50.0))
                     .EnableBatching(true)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer1 =
+            let! (consumer1 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName1)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            let! consumer2 =
+            let! (consumer2 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName2)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -243,12 +244,12 @@ let tests =
                         Log.Debug("consumer2Task finished")
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) 
 
             Log.Debug("Finished Messages with same key always go to the same consumer, when KeyBased batching is enabled")
         }
         
-        testAsync "Messages with same ordering key always go to the same consumer, when KeyBased batching is enabled" {
+        testTask "Messages with same ordering key always go to the same consumer, when KeyBased batching is enabled" {
 
             Log.Debug("Started Messages with same ordering key always go to the same consumer, when KeyBased batching is enabled")
             let client = getClient()
@@ -257,32 +258,32 @@ let tests =
             let consumerName2 = "BatchedPartitionedConsumer2"
             let producerName = "BatchedPartitionedProducer"
 
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .BatchBuilder(BatchBuilder.KeyBased)
                     .BatchingMaxPublishDelay(TimeSpan.FromMilliseconds(50.0))
                     .EnableBatching(true)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer1 =
+            let! (consumer1 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName1)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            let! consumer2 =
+            let! (consumer2 : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .SubscriptionName("test-subscription")
                     .SubscriptionType(SubscriptionType.KeyShared)
                     .AcknowledgementsGroupTime(TimeSpan.FromMilliseconds(50.0))
                     .ConsumerName(consumerName2)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -340,13 +341,13 @@ let tests =
                         Log.Debug("consumer2Task finished")
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumer1Task, consumer2Task) 
 
             Log.Debug("Finished Messages with same ordering key always go to the same consumer, when KeyBased batching is enabled")
         }
 
         // Should be run manually, first with commented consumer, then trigger compaction, then with commented producer
-        ptestAsync "Compacting works as expected" {
+        ptestTask "Compacting works as expected" {
 
             Log.Debug("Started Keys and properties are propertly passed")
             let client = getClient()
@@ -359,7 +360,7 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             //let! consumer =
             //    ConsumerBuilder(client)
@@ -390,7 +391,7 @@ let tests =
                         return ()
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Keys and properties are propertly passed")
         }

--- a/tests/IntegrationTests/Keys.fs
+++ b/tests/IntegrationTests/Keys.fs
@@ -347,7 +347,7 @@ let tests =
         }
 
         // Should be run manually, first with commented consumer, then trigger compaction, then with commented producer
-        ptestTask "Compacting works as expected" {
+        ptestAsync "Compacting works as expected" {
 
             Log.Debug("Started Keys and properties are propertly passed")
             let client = getClient()
@@ -360,7 +360,7 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() 
+                    .CreateAsync() |> Async.AwaitTask
 
             //let! consumer =
             //    ConsumerBuilder(client)
@@ -391,7 +391,7 @@ let tests =
                         return ()
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) 
+            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
 
             Log.Debug("Finished Keys and properties are propertly passed")
         }

--- a/tests/IntegrationTests/Keys.fs
+++ b/tests/IntegrationTests/Keys.fs
@@ -347,7 +347,7 @@ let tests =
         }
 
         // Should be run manually, first with commented consumer, then trigger compaction, then with commented producer
-        ptestAsync "Compacting works as expected" {
+        ptestTask "Compacting works as expected" {
 
             Log.Debug("Started Keys and properties are propertly passed")
             let client = getClient()
@@ -360,7 +360,7 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(producerName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
             //let! consumer =
             //    ConsumerBuilder(client)
@@ -391,7 +391,7 @@ let tests =
                         return ()
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
 
             Log.Debug("Finished Keys and properties are propertly passed")
         }

--- a/tests/IntegrationTests/MultiTopic.fs
+++ b/tests/IntegrationTests/MultiTopic.fs
@@ -139,7 +139,7 @@ let tests =
 
         }
         
-        testTask "Eternal loop to test cluster modifications removal/addition" {
+        ptestTask "Eternal loop to test cluster modifications removal/addition" {
 
             Log.Debug("Started Eternal loop to test cluster modifications removal/addition")
             let client = getClient()
@@ -254,7 +254,7 @@ let tests =
             Log.Debug("Finished Subscribe to new topic")
         }
         
-        testTask "2К of topics" {
+        ptestTask "2К of topics" {
     
             Log.Debug("Started 2К of topics")
             let subscriptionName = "testPulsar"

--- a/tests/IntegrationTests/Reader.fs
+++ b/tests/IntegrationTests/Reader.fs
@@ -315,12 +315,12 @@ let tests =
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestTask "Check StartMessageFromFuturePoint without batching" {
-            do! checkReadingFromFuture false 
+        ptestAsync "Check StartMessageFromFuturePoint without batching" {
+            do! checkReadingFromFuture false |> Async.AwaitTask
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestTask "Check StartMessageFromFuturePoint with batching" {
-            do! checkReadingFromFuture true 
+        ptestAsync "Check StartMessageFromFuturePoint with batching" {
+            do! checkReadingFromFuture true |> Async.AwaitTask
         }
     ]

--- a/tests/IntegrationTests/Reader.fs
+++ b/tests/IntegrationTests/Reader.fs
@@ -315,12 +315,12 @@ let tests =
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestAsync "Check StartMessageFromFuturePoint without batching" {
-            do! checkReadingFromFuture false |> Async.AwaitTask
+        ptestTask "Check StartMessageFromFuturePoint without batching" {
+            do! checkReadingFromFuture false 
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestAsync "Check StartMessageFromFuturePoint with batching" {
-            do! checkReadingFromFuture true |> Async.AwaitTask
+        ptestTask "Check StartMessageFromFuturePoint with batching" {
+            do! checkReadingFromFuture true 
         }
     ]

--- a/tests/IntegrationTests/Reader.fs
+++ b/tests/IntegrationTests/Reader.fs
@@ -274,53 +274,53 @@ let tests =
 
     testList "Reader" [
 
-        testAsync "Reader non-batching configuration works fine" {
-            do! basicReaderCheck false |> Async.AwaitTask
+        testTask "Reader non-batching configuration works fine" {
+            do! basicReaderCheck false 
         }
 
-        testAsync "Reader batching configuration works fine" {
-            do! basicReaderCheck true |> Async.AwaitTask
+        testTask "Reader batching configuration works fine" {
+            do! basicReaderCheck true 
         }
 
-        testAsync "Muliple readers non-batching configuration works fine" {
-            do! checkMultipleReaders false |> Async.AwaitTask
+        testTask "Muliple readers non-batching configuration works fine" {
+            do! checkMultipleReaders false 
         }
 
-        testAsync "Muliple readers batching configuration works fine" {
-            do! checkMultipleReaders true |> Async.AwaitTask
+        testTask "Muliple readers batching configuration works fine" {
+            do! checkMultipleReaders true 
         }
 
-        testAsync "Check reading from producer messageId without batching" {
-            do! checkReadingFromProducerMessageId false |> Async.AwaitTask
+        testTask "Check reading from producer messageId without batching" {
+            do! checkReadingFromProducerMessageId false 
         }
 
-        testAsync "Check reading from producer messageId with batching" {
-            do! checkReadingFromProducerMessageId true |> Async.AwaitTask
+        testTask "Check reading from producer messageId with batching" {
+            do! checkReadingFromProducerMessageId true 
         }
         
-        testAsync "Check reading from last messageId without batching" {
-            do! checkReadingFromLastMessageId false |> Async.AwaitTask
+        testTask "Check reading from last messageId without batching" {
+            do! checkReadingFromLastMessageId false 
         }
         
-        testAsync "Check reading from last messageId with batching" {
-            do! checkReadingFromLastMessageId true |> Async.AwaitTask
+        testTask "Check reading from last messageId with batching" {
+            do! checkReadingFromLastMessageId true 
         }
         
-        testAsync "Check StartMessageFromRollbackDuration without batching" {
-            do! checkReadingFromRollback false |> Async.AwaitTask
+        testTask "Check StartMessageFromRollbackDuration without batching" {
+            do! checkReadingFromRollback false 
         }
         
-        testAsync "Check StartMessageFromRollbackDuration with batching" {
-            do! checkReadingFromRollback true |> Async.AwaitTask
+        testTask "Check StartMessageFromRollbackDuration with batching" {
+            do! checkReadingFromRollback true 
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestAsync "Check StartMessageFromFuturePoint without batching" {
-            do! checkReadingFromFuture false |> Async.AwaitTask
+        ptestTask "Check StartMessageFromFuturePoint without batching" {
+            do! checkReadingFromFuture false 
         }
         
         // uncomment when https://github.com/apache/pulsar/issues/10515 is ready
-        ptestAsync "Check StartMessageFromFuturePoint with batching" {
-            do! checkReadingFromFuture true |> Async.AwaitTask
+        ptestTask "Check StartMessageFromFuturePoint with batching" {
+            do! checkReadingFromFuture true 
         }
     ]

--- a/tests/IntegrationTests/Schema.fs
+++ b/tests/IntegrationTests/Schema.fs
@@ -1,6 +1,7 @@
 module Pulsar.Client.IntegrationTests.Schema
 
 open System.ComponentModel.DataAnnotations
+open Avro.Generic
 open AvroSchemaGenerator.Attributes
 open Expecto
 open Expecto.Flip
@@ -58,94 +59,94 @@ let tests =
 
     testList "schema" [
 
-        testAsync "String schema works fine" {
+        testTask "String schema works fine" {
 
             Log.Debug("Start String schema works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "stringSchema"
 
-            let! producer =
+            let! (producer : IProducer<string>) =
                 client.NewProducer(Schema.STRING())
                     .Topic(topicName)
                     .ProducerName(name)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<string>) =
                 client.NewConsumer(Schema.STRING())
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let sentText = "Hello schema"
-            let! _ = producer.SendAsync(sentText) |> Async.AwaitTask
+            let! _ = producer.SendAsync(sentText) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<string>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
 
             Expect.equal "" sentText (msg.GetValue())
 
             Log.Debug("Finished String schema works fine")
         }
         
-        testAsync "Json schema works fine" {
+        testTask "Json schema works fine" {
 
             Log.Debug("Start Json schema works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "jsonSchema"
 
-            let! producer =
+            let! (producer : IProducer<SimpleRecord3>) =
                 client.NewProducer(Schema.JSON<SimpleRecord3>())
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<SimpleRecord3>) =
                 client.NewConsumer(Schema.JSON<SimpleRecord3>())
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleRecord3.Name = "abc"; Age = 20; Date = DateTime.UtcNow }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<SimpleRecord3>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
 
             Expect.equal "" input (msg.GetValue())
 
             Log.Debug("Finished Json schema works fine")
         }
         
-        testAsync "KeyValue schema separated works fine" {
+        testTask "KeyValue schema separated works fine" {
 
             Log.Debug("Start KeyValue schema separated works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "keyValueSeparatedSchema"
 
-            let! producer =
+            let! (producer : IProducer<KeyValuePair<bool,string>>) =
                 client.NewProducer(Schema.KEY_VALUE(Schema.BOOL(), Schema.STRING(), KeyValueEncodingType.SEPARATED))
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<KeyValuePair<bool,string>>) =
                 client.NewConsumer(Schema.KEY_VALUE(Schema.BOOL(), Schema.STRING(), KeyValueEncodingType.SEPARATED))
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            let! _ = producer.SendAsync(KeyValuePair(true, "one")) |> Async.AwaitTask
+            let! _ = producer.SendAsync(KeyValuePair(true, "one")) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<KeyValuePair<bool,string>>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
             
             Expect.isTrue "" msg.HasBase64EncodedKey
             Expect.equal "" "one" (msg.GetValue()).Value
@@ -154,31 +155,31 @@ let tests =
             Log.Debug("Finished KeyValue schema separated works fine")
         }
         
-        testAsync "KeyValue schema inline works fine" {
+        testTask "KeyValue schema inline works fine" {
 
             Log.Debug("Start KeyValue schema inline works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "keyValueInlineSchema"
 
-            let! producer =
+            let! (producer : IProducer<KeyValuePair<bool,string>>) =
                 client.NewProducer(Schema.KEY_VALUE(Schema.BOOL(), Schema.STRING(), KeyValueEncodingType.INLINE))
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<KeyValuePair<bool,string>>) =
                 client.NewConsumer(Schema.KEY_VALUE(Schema.BOOL(), Schema.STRING(), KeyValueEncodingType.INLINE))
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
-            let! _ = producer.SendAsync(KeyValuePair(true, "one")) |> Async.AwaitTask
+            let! _ = producer.SendAsync(KeyValuePair(true, "one")) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<KeyValuePair<bool,string>>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
             
             Expect.isFalse "" msg.HasBase64EncodedKey
             Expect.equal "" "one" (msg.GetValue()).Value
@@ -187,101 +188,101 @@ let tests =
             Log.Debug("Finished KeyValue schema inline works fine")
         }
         
-        testAsync "Protobuf schema works fine" {
+        testTask "Protobuf schema works fine" {
 
             Log.Debug("Start Protobuf schema works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "protobufSchema"
 
-            let! producer =
+            let! (producer : IProducer<SimpleProtoRecord>) =
                 client.NewProducer(Schema.PROTOBUF<SimpleProtoRecord>())
                     .Topic(topicName)
                     .ProducerName(name)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<SimpleProtoRecord>) =
                 client.NewConsumer(Schema.PROTOBUF<SimpleProtoRecord>())
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleProtoRecord.Name = "abc"; Age = 20  }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<SimpleProtoRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
 
             Expect.equal "" input (msg.GetValue())
 
             Log.Debug("Finished Protobuf schema works fine")
         }
         
-        testAsync "ProtobufNative schema works fine" {
+        testTask "ProtobufNative schema works fine" {
 
             Log.Debug("Start ProtobufNative schema works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "protobufNativeSchema"
 
-            let! producer =
+            let! (producer : IProducer<SimpleProtoRecord>) =
                 client.NewProducer(Schema.PROTOBUF_NATIVE<SimpleProtoRecord>())
                     .Topic(topicName)
                     .ProducerName(name)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<SimpleProtoRecord>) =
                 client.NewConsumer(Schema.PROTOBUF_NATIVE<SimpleProtoRecord>())
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleProtoRecord.Name = "abc"; Age = 20  }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<SimpleProtoRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
 
             Expect.equal "" input (msg.GetValue())
 
             Log.Debug("Finished ProtobufNative schema works fine")
         }
         
-        testAsync "Avro schema works fine" {
+        testTask "Avro schema works fine" {
 
             Log.Debug("Start Avro schema works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "avroSchema"
 
-            let! producer =
+            let! (producer : IProducer<SimpleRecord>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<SimpleRecord>) =
                 client.NewConsumer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleRecord.Name = "abc"; Age = 20 }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<SimpleRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
 
             Expect.equal "" input (msg.GetValue())
 
             Log.Debug("Finished Avro schema works fine")
         }
         
-        testAsync "Incompatible record errors" {
+        testTask "Incompatible record errors" {
 
             Log.Debug("Start Incompatible record errors")
             let client = getClient()
@@ -293,7 +294,7 @@ let tests =
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
                     
             Expect.throwsT2<IncompatibleSchemaException> (fun () ->                    
                     client.NewConsumer(Schema.AVRO<IncompatibleRecord>())
@@ -306,87 +307,87 @@ let tests =
             Log.Debug("Finished Incompatible record errors")
         }
         
-        testAsync "Avro schema upgrade works fine" {
+        testTask "Avro schema upgrade works fine" {
 
             Log.Debug("Start Avro schema upgrade works fine")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
 
-            let! producer =
+            let! (producer : IProducer<SimpleRecord>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName)
                     .ProducerName("avroUpgradeSchema1")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<SimpleRecord>) =
                 client.NewConsumer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName)
                     .ConsumerName("avroUpgradeSchema1")
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleRecord.Name = "abc"; Age = 20 }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<SimpleRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
             Expect.equal "" input (msg.GetValue())
             
-            do! consumer.UnsubscribeAsync() |> Async.AwaitTask            
+            do! consumer.UnsubscribeAsync()             
                     
-            let! producer2 =
+            let! (producer2 : IProducer<SimpleRecord2>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord2>())
                     .Topic(topicName)
                     .ProducerName("avroUpgradeSchema2")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer2 =
+            let! (consumer2 : IConsumer<SimpleRecord2>) =
                 client.NewConsumer(Schema.AVRO<SimpleRecord2>())
                     .Topic(topicName)
                     .ConsumerName("avroUpgradeSchema2")
                     .SubscriptionName("test-subscription2")
                     .SubscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input2 = { SimpleRecord2.Name = "abc"; Age = 20; Surname = "Jones" }
-            let! _ = producer2.SendAsync(input2) |> Async.AwaitTask
+            let! _ = producer2.SendAsync(input2) 
 
-            let! msg1 = consumer2.ReceiveAsync() |> Async.AwaitTask
-            do! consumer2.AcknowledgeAsync msg1.MessageId |> Async.AwaitTask
-            let! msg2 = consumer2.ReceiveAsync() |> Async.AwaitTask
-            do! consumer2.AcknowledgeAsync msg2.MessageId |> Async.AwaitTask
-            do! consumer2.UnsubscribeAsync() |> Async.AwaitTask
+            let! (msg1 : Message<SimpleRecord2>) = consumer2.ReceiveAsync() 
+            do! consumer2.AcknowledgeAsync msg1.MessageId 
+            let! (msg2 : Message<SimpleRecord2>) = consumer2.ReceiveAsync() 
+            do! consumer2.AcknowledgeAsync msg2.MessageId 
+            do! consumer2.UnsubscribeAsync() 
             Expect.equal "" { input2 with Surname = null } (msg1.GetValue())
             Expect.equal "" input2 (msg2.GetValue())
             
             Log.Debug("Finished Avro schema upgrade works fine")
         }
-        testAsync "Autoproduce and autoConsume protobuf native schema works fine" {
+        testTask "Autoproduce and autoConsume protobuf native schema works fine" {
             let client = getClient()
             let topicName1 = "public/default/topic-" + Guid.NewGuid().ToString("N")          
 
-            let! producer =
+            let! (producer : IProducer<SimpleProtoRecord>) =
                 client.NewProducer(Schema.PROTOBUF_NATIVE<SimpleProtoRecord>())
                     .Topic(topicName1)
                     .ProducerName("autoNormal")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<GenericRecord>) =
                 client.NewConsumer(Schema.AUTO_CONSUME())
                     .Topic(topicName1)
                     .ConsumerName("autoConsume")
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleProtoRecord.Name = "abc"; Age = 20 }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg1 = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg1.MessageId |> Async.AwaitTask
-            do! consumer.UnsubscribeAsync() |> Async.AwaitTask
+            let! (msg1 : Message<GenericRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg1.MessageId 
+            do! consumer.UnsubscribeAsync() 
             let genericRecord = msg1.GetValue()
             Expect.equal "" input.Name (genericRecord.GetField("Name") |> unbox)
             Expect.equal "" input.Age (genericRecord.GetField("Age") |> unbox)
@@ -395,57 +396,57 @@ let tests =
             Log.Debug("Finished Autoproduce protobuf native schema works fine")
         }
 
-        testAsync "Autoproduce and autoConsume schema works fine" {
+        testTask "Autoproduce and autoConsume schema works fine" {
 
             Log.Debug("Start Autoproduce schema works fine")
             let client = getClient()
             let topicName1 = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let topicName2 = "public/default/topic-" + Guid.NewGuid().ToString("N")
 
-            let! producer =
+            let! (producer : IProducer<SimpleRecord>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName1)
                     .ProducerName("autoNormal")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<GenericRecord>) =
                 client.NewConsumer(Schema.AUTO_CONSUME())
                     .Topic(topicName1)
                     .ConsumerName("autoConsume")
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let input = { SimpleRecord.Name = "abc"; Age = 20 }
-            let! _ = producer.SendAsync(input) |> Async.AwaitTask
+            let! _ = producer.SendAsync(input) 
 
-            let! msg1 = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg1.MessageId |> Async.AwaitTask
-            do! consumer.UnsubscribeAsync() |> Async.AwaitTask
+            let! (msg1 : Message<GenericRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg1.MessageId 
+            do! consumer.UnsubscribeAsync() 
             let genericRecord = msg1.GetValue()
             Expect.equal "" input.Name (genericRecord.GetField("Name") |> unbox)
             Expect.equal "" input.Age (genericRecord.GetField("Age") |> unbox)
             
             
-            let! consumer2 =
+            let! (consumer2 : IConsumer<SimpleRecord>) =
                 client.NewConsumer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName2)
                     .ConsumerName("autoNormal")
                     .SubscriptionName("test-subscription")
                     .SubscriptionInitialPosition(SubscriptionInitialPosition.Earliest)
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
             
-            let! producer2 =
+            let! (producer2 : IProducer<byte[]>) =
                 client.NewProducer(Schema.AUTO_PRODUCE())
                     .Topic(topicName2)
                     .ProducerName("autoProduce")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! _ = producer2.SendAsync(msg1.Data) |> Async.AwaitTask
+            let! _ = producer2.SendAsync(msg1.Data) 
 
-            let! msg1 = consumer2.ReceiveAsync() |> Async.AwaitTask
-            do! consumer2.UnsubscribeAsync() |> Async.AwaitTask
+            let! (msg1 : Message<SimpleRecord>) = consumer2.ReceiveAsync() 
+            do! consumer2.UnsubscribeAsync() 
             let avroRecord = msg1.GetValue()
             Expect.equal "" input.Age avroRecord.Age
             Expect.equal "" input.Name avroRecord.Name
@@ -453,89 +454,89 @@ let tests =
             Log.Debug("Finished Autoproduce schema works fine")
         }
         
-        testAsync "Auto produce KeyValue with nested object works" {
+        testTask "Auto produce KeyValue with nested object works" {
 
             Log.Debug("Start Auto consume KeyValue with nested object works")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let name = "autoProduceKeyValue"
 
-            let! producer =
+            let! (producer : IProducer<KeyValuePair<SimpleRecord,IncompatibleRecord>>) =
                 client.NewProducer(Schema.KEY_VALUE<SimpleRecord, IncompatibleRecord>(SchemaType.AVRO))
                     .Topic(topicName)
                     .ProducerName(name)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
                     
-            let! producer2 =
+            let! (producer2 : IProducer<byte[]>) =
                 client.NewProducer(Schema.AUTO_PRODUCE())
                     .Topic(topicName)
                     .ProducerName(name + "Main")
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<KeyValuePair<SimpleRecord,IncompatibleRecord>>) =
                 client.NewConsumer(Schema.KEY_VALUE<SimpleRecord, IncompatibleRecord>(SchemaType.AVRO))
                     .Topic(topicName)
                     .ConsumerName(name)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let keyInput = { SimpleRecord.Name = "abc"; Age = 20 }
             let valueInput = { IncompatibleRecord.Name = 20; Age = "abc" }
-            let! _ = producer.SendAsync(KeyValuePair(keyInput, valueInput)) |> Async.AwaitTask
+            let! _ = producer.SendAsync(KeyValuePair(keyInput, valueInput)) 
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<KeyValuePair<SimpleRecord,IncompatibleRecord>>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
             let (KeyValue(key, value)) = msg.GetValue()
             Expect.equal "" keyInput key
             Expect.equal "" valueInput value
             
-            let! _ = producer2.SendAsync(msg.Data) |> Async.AwaitTask
-            let! msg2 = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg2.MessageId |> Async.AwaitTask
+            let! _ = producer2.SendAsync(msg.Data) 
+            let! (msg2 : Message<KeyValuePair<SimpleRecord,IncompatibleRecord>>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg2.MessageId 
             let (KeyValue(key2, value2)) = msg2.GetValue()
             Expect.equal "" keyInput key2
             Expect.equal "" valueInput value2
             
-            do! consumer.UnsubscribeAsync() |> Async.AwaitTask
+            do! consumer.UnsubscribeAsync() 
             
           
             Log.Debug("Finished Auto consume KeyValue with nested object works")
         }
         
-        testAsync "Auto consume with multi-version schema" {
+        testTask "Auto consume with multi-version schema" {
 
             Log.Debug("Start Auto consume with multi-version schema")
             let client = getClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
 
-            let! producer =
+            let! (producer : IProducer<SimpleRecord2>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord2>())
                     .Topic(topicName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
                     
-            let! producer2 =
+            let! (producer2 : IProducer<SimpleRecord>) =
                 client.NewProducer(Schema.AVRO<SimpleRecord>())
                     .Topic(topicName)
                     .EnableBatching(false)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
 
-            let! consumer =
+            let! (consumer : IConsumer<GenericRecord>) =
                 client.NewConsumer(Schema.AUTO_CONSUME())
                     .Topic(topicName)
                     .ConsumerName("auto-consume")
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let simpleMessage = { SimpleRecord2.Name = "abc"; Age = 21; Surname = "test" }
             let simpleMessage2 = { SimpleRecord.Name = "def"; Age = 20 }
-            let! _ = producer.SendAsync(simpleMessage) |> Async.AwaitTask // send the first version message
-            let! _ = producer2.SendAsync(simpleMessage2) |> Async.AwaitTask // send the second version message
+            let! _ = producer.SendAsync(simpleMessage)  // send the first version message
+            let! _ = producer2.SendAsync(simpleMessage2)  // send the second version message
 
-            let! msg = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg.MessageId |> Async.AwaitTask
+            let! (msg : Message<GenericRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg.MessageId 
             let record = msg.GetValue()
             // we could get the correct schema version for each message.
             Expect.equal "" 0L (BitConverter.ToInt64(ReadOnlySpan<byte>(record.SchemaVersion |> Array.rev)))
@@ -543,14 +544,14 @@ let tests =
             Expect.equal "" simpleMessage.Age (record.GetField("Age") |> unbox)
             Expect.equal "" simpleMessage.Surname (record.GetField("Surname") |> unbox)
             
-            let! msg2 = consumer.ReceiveAsync() |> Async.AwaitTask
-            do! consumer.AcknowledgeAsync msg2.MessageId |> Async.AwaitTask
+            let! (msg2 : Message<GenericRecord>) = consumer.ReceiveAsync() 
+            do! consumer.AcknowledgeAsync msg2.MessageId 
             let record2 = msg2.GetValue()
             Expect.equal "" 1L (BitConverter.ToInt64( ReadOnlySpan<byte>(record2.SchemaVersion |> Array.rev)))
             Expect.equal "" simpleMessage2.Name (record2.GetField("Name") |> unbox)
             Expect.equal "" simpleMessage2.Age (record2.GetField("Age") |> unbox)
             
-            do! consumer.UnsubscribeAsync() |> Async.AwaitTask
+            do! consumer.UnsubscribeAsync() 
           
             Log.Debug("Finished Auto consume with multi-version schema")
         }

--- a/tests/IntegrationTests/Stats.fs
+++ b/tests/IntegrationTests/Stats.fs
@@ -10,7 +10,7 @@ open Pulsar.Client.IntegrationTests.Common
 [<Tests>]
 let tests =
     testList "Stats" [
-        testAsync "Consumer and Producer stats" {
+        testTask "Consumer and Producer stats" {
             let client = getStatsClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let numberOfMessages = 10
@@ -19,14 +19,14 @@ let tests =
             let! producer =
                 client.NewProducer()
                     .Topic(topicName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
             let! consumer =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName(consumerName)
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
+                    .SubscribeAsync() 
 
             let producerTask =
                 Task.Run(fun () ->
@@ -40,11 +40,11 @@ let tests =
                         do! consumeMessages consumer numberOfMessages consumerName
                     }:> Task)
               
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
-            do! Async.Sleep 1000
-            let! producerStats = producer.GetStatsAsync() |> Async.AwaitTask
-            do! Async.Sleep 1000
-            let! consumerStats = consumer.GetStatsAsync() |> Async.AwaitTask
+            do! Task.WhenAll(producerTask, consumerTask) 
+            do! Task.Delay 1000
+            let! producerStats = producer.GetStatsAsync() 
+            do! Task.Delay 1000
+            let! consumerStats = consumer.GetStatsAsync() 
             
             let numberOfMessages = int64 numberOfMessages
             Expect.equal producerStats.TotalMsgsSent numberOfMessages "The producStats.TotalMsgsSent is not equal to numberOfMessages" 

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -6,6 +6,7 @@ open System
 open Expecto
 
 open System.Threading.Tasks
+open Pulsar.Client.Api
 open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 
@@ -13,24 +14,24 @@ open Pulsar.Client.IntegrationTests.Common
 [<Tests>]
 let tests =
     testList "Tls" [
-        testAsync "Tls transport" {
+        testTask "Tls transport" {
             let client = getSslAdminClient()
             let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
             let numberOfMessages = 10
             let messageIds = ResizeArray<MessageId>()
             
-            let! producer =
+            let! (producer : IProducer<byte[]>) =
                 client.NewProducer()
                     .Topic(topicName)
-                    .CreateAsync() |> Async.AwaitTask
+                    .CreateAsync() 
             
-            let! consumer =
+            let! (consumer : IConsumer<byte[]>) =
                 client.NewConsumer()
                     .Topic(topicName)
                     .ConsumerName("concurrent")
                     .SubscriptionName("test-subscription")
-                    .SubscribeAsync() |> Async.AwaitTask
-
+                    .SubscribeAsync()
+                    
             let producerTask =
                 Task.Run(fun () ->
                     task {
@@ -46,8 +47,7 @@ let tests =
                         do! consumer.DisposeAsync()
                     }:> Task)
 
-            do! Task.WhenAll(producerTask, consumerTask) |> Async.AwaitTask
-
+            do! Task.WhenAll(producerTask, consumerTask) 
         }
 
     ]

--- a/tests/UnitTests/Common/ExceptionsTests.fs
+++ b/tests/UnitTests/Common/ExceptionsTests.fs
@@ -12,32 +12,28 @@ open Pulsar.Client.Common
 let tests =
 
     testList "TopicNameTests" [
-        testAsync "Aggregate exception is caught" {
+        testTask "Aggregate exception is caught" {
             try
                 do!
                     Task.Run(fun () -> raise <| CryptoException "sdf")
-                    |> Async.AwaitTask
-                    |> Async.Ignore
             with Flatten ex ->
                 Expect.isTrue "" (ex :? CryptoException)
         }
         
-        testAsync "Double aggregate exception is caught" {
+        testTask "Double aggregate exception is caught" {
             try
                 do!
                     Task.Run<unit>(fun () -> task {
                         return!
                             Task.Run<unit>(fun () -> task {
                                 raise <| CryptoException "sdf"
-                            }) |> Async.AwaitTask
+                            }) 
                     })
-                    |> Async.AwaitTask
-                    |> Async.Ignore
             with Flatten ex ->
                 Expect.isTrue "" (ex :? CryptoException)
         }
         
-        testAsync "Normal exception is caught" {
+        testTask "Normal exception is caught" {
             try
                 raise <| CryptoException "sdf"
             with Flatten ex ->

--- a/tests/UnitTests/Common/ToolsTests.fs
+++ b/tests/UnitTests/Common/ToolsTests.fs
@@ -2,6 +2,7 @@ module Pulsar.Client.UnitTests.Common.ToolsTests
 
 open System
 open System.Collections
+open System.Threading.Tasks
 open Expecto
 open Expecto.Flip
 open Pulsar.Client.Common
@@ -64,12 +65,12 @@ let tests =
                 Expect.isFalse "" equalityResult.[i]
         }
         
-        testAsync "Async delay shouldn't crash process" {
+        testTask "Async delay shouldn't crash process" {
             let x = true
             let f = fun () -> failwith "failure"
             asyncDelayMs 20 f
-            do! Async.Sleep 100
-            do! Async.Sleep 100
+            do! Task.Delay 100
+            do! Task.Delay 100
             Console.WriteLine(x)
             Expect.isTrue "" x
         }

--- a/tests/UnitTests/Internal/ChunkedMessageTrackerTests.fs
+++ b/tests/UnitTests/Internal/ChunkedMessageTrackerTests.fs
@@ -1,6 +1,7 @@
 module Pulsar.Client.UnitTests.Internal.ChunkedMessageTrackerTests
 
 open System
+open System.Threading.Tasks
 open Expecto
 open Expecto.Flip
 open Pulsar.Client.Internal
@@ -126,7 +127,7 @@ let tests =
             Expect.equal "" xMsgId msgId1
         }
         
-        testAsync "Tracker timeout works as expected" {
+        testTask "Tracker timeout works as expected" {
             let mutable xShouldAck = false
             let mutable xMsgId = Unchecked.defaultof<MessageId>
             let ackOrTrack msgId shouldAck =
@@ -143,7 +144,7 @@ let tests =
                 Expect.isNone "" firstTry
             | _ ->
                 failwith "No context"
-            do! Async.Sleep 70
+            do! Task.Delay 70
             tracker.RemoveExpireIncompleteChunkedMessages()
             let metadata3 = { testMetadata with NumChunks = 2; TotalChunkMsgSize = 2; Uuid = %"1"; ChunkId = %1 }
             let context = tracker.GetContext(metadata3)

--- a/tests/UnitTests/Internal/NegativeAcksTracker.fs
+++ b/tests/UnitTests/Internal/NegativeAcksTracker.fs
@@ -14,7 +14,7 @@ let tests =
 
     testList "NegativeAcksTracker" [
 
-        testAsync "UnAckedMessageTracker redeliver all works" {
+        testTask "UnAckedMessageTracker redeliver all works" {
             
             let scheduler = new ManualInvokeScheduler()
             let getScheduler onTick =
@@ -35,15 +35,15 @@ let tests =
             tracker.Add msgId2 |> Expect.isTrue ""
             tracker.Add msgId3 |> Expect.isTrue ""
             
-            do! Async.Sleep(120) //waiting for expiration to happen
+            do! Task.Delay(120) //waiting for expiration to happen
             scheduler.Tick()     //ticking timer
             
-            let! redelivered = tsc.Task |> Async.AwaitTask
+            let! redelivered = tsc.Task 
             redelivered |> Expect.equal "" 3
             tracker.Close()
         }
 
-        testAsync "UnAckedMessageTracker redeliver one and then two works" {
+        testTask "UnAckedMessageTracker redeliver one and then two works" {
             
             let scheduler = new ManualInvokeScheduler()
             let getScheduler onTick =
@@ -61,21 +61,21 @@ let tests =
             let msgId3 = { msgId1 with EntryId = %3L }
             
             tracker.Add msgId1 |> Expect.isTrue ""
-            do! Async.Sleep(35)  //waiting for step expiration to happen
+            do! Task.Delay(35)  //waiting for step expiration to happen
             scheduler.Tick()     //ticking timer
             
             tracker.Add msgId2 |> Expect.isTrue ""
             tracker.Add msgId3 |> Expect.isTrue ""
-            do! Async.Sleep(70)  //waiting for double step expiration
+            do! Task.Delay(70)  //waiting for double step expiration
             scheduler.Tick()     //ticking timer
             
-            let! redelivered1 = tcs.Task |> Async.AwaitTask
+            let! redelivered1 = tcs.Task 
             redelivered1 |> Expect.equal "" 1
             
             tcs <- TaskCompletionSource<int>()
-            do! Async.Sleep(35)  //waiting for one more stop expiration to happen
+            do! Task.Delay(35)  //waiting for one more stop expiration to happen
             scheduler.Tick()     //ticking timer
-            let! redelivered2 = tcs.Task |> Async.AwaitTask
+            let! redelivered2 = tcs.Task 
             redelivered2 |> Expect.equal "" 2
             tracker.Close()
         }

--- a/tests/UnitTests/Internal/StatsTests.fs
+++ b/tests/UnitTests/Internal/StatsTests.fs
@@ -1,5 +1,6 @@
 ﻿module Pulsar.Client.UnitTests.Internal.Stats
 
+open System.Threading.Tasks
 open Expecto
 open Expecto.Flip
 open Pulsar.Client.Internal
@@ -11,7 +12,7 @@ let tests =
 
     testList "Stats" [
 
-        testAsync "Producer stats" {
+        testTask "Producer stats" {
             let stats = ProducerStatsImpl("unit_test") :> IProducerStatsRecorder
             let numberOfMessages = 10L
             let messageSize = 50L
@@ -26,7 +27,7 @@ let tests =
             let realBeforeTick = stats.GetStats()
             stats.TickTime(5)
             let realAfterTick = stats.GetStats()
-            do! Async.Sleep 10 // need to have a duration of large zero
+            do! Task.Delay 10 // need to have a duration of large zero
             stats.TickTime(3)
             let realAfter2Tick = stats.GetStats()
             
@@ -92,7 +93,7 @@ let tests =
             Expect.equal "" realAfter2Tick expectedAfter2Tick
         }
         
-        testAsync "Consumer stats" {
+        testTask "Consumer stats" {
             let stats = ConsumerStatsImpl("unit_test") :> IConsumerStatsRecorder
             let numberOfMessages = 10L
             let messageSize = 50L
@@ -107,7 +108,7 @@ let tests =
             let realBeforeTick = stats.GetStats()
             stats.TickTime(5)
             let realAfterTick = stats.GetStats()
-            do! Async.Sleep 10 // need to have a duration of large zero
+            do! Task.Delay 10 // need to have a duration of large zero
             stats.TickTime(3)
             let realAfter2Tick = stats.GetStats()
 

--- a/tests/UnitTests/Internal/TaskSeq.fs
+++ b/tests/UnitTests/Internal/TaskSeq.fs
@@ -18,7 +18,7 @@ let tests =
     
     testList "TaskSeq tests" [
 
-        testAsync "Empty input doesn't throw" {
+        testTask "Empty input doesn't throw" {
             let ts = TaskSeq(Seq.empty)
             let task1 = task {
                 let! _ = ts.Next()
@@ -28,11 +28,15 @@ let tests =
                 let! _ = Task.Delay(100)
                 return 2
             }
-            let! result = Task.WhenAny(task1, task2) |> Async.AwaitTask
-            Expect.equal "" 2 result.Result
+                        
+            let! (resultTask : Task<int>) = Task.WhenAny(task1, task2)
+            
+            let! result = resultTask
+            
+            Expect.equal "" 2 result
         }
         
-        testAsync "Initial generators work well" {
+        testTask "Initial generators work well" {
             let gen1 = fun () -> task {
                 do! Task.Delay(100)
                 return 100
@@ -42,10 +46,10 @@ let tests =
                 return 40
             }            
             let ts = TaskSeq([gen1; gen2])
-            let! result1 = ts.Next() |> Async.AwaitTask
-            let! result2 = ts.Next() |> Async.AwaitTask
-            let! result3 = ts.Next() |> Async.AwaitTask
-            let! result4 = ts.Next() |> Async.AwaitTask
+            let! result1 = ts.Next() 
+            let! result2 = ts.Next() 
+            let! result3 = ts.Next() 
+            let! result4 = ts.Next() 
             
             Expect.equal "" 40 result1
             Expect.equal "" 40 result2
@@ -53,7 +57,7 @@ let tests =
             Expect.equal "" 40 result4
         }
         
-        testAsync "Additional generator work well" {
+        testTask "Additional generator work well" {
             let gen1 = fun () -> task {
                 do! Task.Delay(100)
                 return 100
@@ -67,12 +71,12 @@ let tests =
                 return 40
             }
             let ts = TaskSeq([gen1; gen2])
-            let! result1 = ts.Next() |> Async.AwaitTask
+            let! result1 = ts.Next() 
             ts.AddGenerators([gen3])
-            let! result2 = ts.Next() |> Async.AwaitTask
-            let! result3 = ts.Next() |> Async.AwaitTask
-            let! result4 = ts.Next() |> Async.AwaitTask
-            let! result5 = ts.Next() |> Async.AwaitTask
+            let! result2 = ts.Next() 
+            let! result3 = ts.Next() 
+            let! result4 = ts.Next() 
+            let! result5 = ts.Next() 
             
             Expect.equal "" 100 result1
             Expect.equal "" 100 result2
@@ -81,7 +85,7 @@ let tests =
             Expect.equal "" 100 result5
         }
         
-        testAsync "Add/Remove generator work well" {
+        testTask "Add/Remove generator work well" {
             let gen1 = fun () -> task {
                 do! Task.Delay(100)
                 return 100
@@ -93,10 +97,10 @@ let tests =
             let ts = TaskSeq<int>(Seq.empty)
             let result1Task = ts.Next()
             ts.AddGenerators([gen1; gen2])
-            let! result2 = ts.Next() |> Async.AwaitTask
-            let! result3 = ts.Next() |> Async.AwaitTask
+            let! result2 = ts.Next() 
+            let! result3 = ts.Next() 
             ts.RemoveGenerator(gen2)
-            let! result4 = ts.Next() |> Async.AwaitTask
+            let! result4 = ts.Next() 
             
             Expect.equal "" 40 result1Task.Result
             Expect.equal "" 40 result2
@@ -104,7 +108,7 @@ let tests =
             Expect.equal "" 100 result4
         }
         
-        testAsync "Adding generator resets waitAny" {
+        testTask "Adding generator resets waitAny" {
             
             let gen1 = fun () -> task {
                 do! Task.Delay(1000)
@@ -117,15 +121,15 @@ let tests =
             let ts = TaskSeq<int>([gen1])
             let result1Task = ts.Next()
             ts.AddGenerators([gen2])
-            let! result2 = ts.Next() |> Async.AwaitTask
-            let! result3 = ts.Next() |> Async.AwaitTask
+            let! result2 = ts.Next() 
+            let! result3 = ts.Next() 
             
             Expect.equal "" 400 result1Task.Result
             Expect.equal "" 400 result2
             Expect.equal "" 1000 result3
         }
         
-        testAsync "Parallel waiters work fine" {
+        testTask "Parallel waiters work fine" {
             let gen1 = fun () -> task {
                 do! Task.Delay(550)
                 return 550
@@ -147,7 +151,7 @@ let tests =
             let result2Task = ts.Next()
             let result3Task = ts.Next()
             ts.AddGenerators([gen3; gen4])
-            let! result4 = ts.Next() |> Async.AwaitTask
+            let! result4 = ts.Next() 
             
             Expect.equal "" 400 result1Task.Result
             Expect.equal "" 450 result2Task.Result
@@ -155,7 +159,7 @@ let tests =
             Expect.equal "" 550 result4
         }
         
-        testAsync "Multiple add generators works fine" {
+        testTask "Multiple add generators works fine" {
             let gen1 = fun () -> task {
                 do! Task.Delay(550)
                 return 550
@@ -178,7 +182,7 @@ let tests =
             let result3Task = ts.Next()
             ts.AddGenerators([gen3])
             ts.AddGenerators([gen4])
-            let! result4 = ts.Next() |> Async.AwaitTask
+            let! result4 = ts.Next() 
             
             Expect.equal "" 400 result1Task.Result
             Expect.equal "" 450 result2Task.Result
@@ -186,7 +190,7 @@ let tests =
             Expect.equal "" 550 result4
         }
         
-        testAsync "Completed tasks come in unpredicted order" {
+        testTask "Completed tasks come in unpredicted order" {
             
             let gen1 = fun () -> Task.FromResult(1)
             let gen2 = fun () -> Task.FromResult(2)

--- a/tests/UnitTests/Internal/Transaction.fs
+++ b/tests/UnitTests/Internal/Transaction.fs
@@ -15,7 +15,7 @@ let tests =
     
     testList "Transaction tests" [
         
-        testAsync "Registering topic multiple times with same subscription returns same task" {
+        testTask "Registering topic multiple times with same subscription returns same task" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -39,7 +39,7 @@ let tests =
             Expect.allEqual "" results.[0] results
         }
         
-        testAsync "Registering topic multiple times with different subscriptions returns different tasks" {
+        testTask "Registering topic multiple times with different subscriptions returns different tasks" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -73,7 +73,7 @@ let tests =
             Expect.notEqual "" results.[0] results.[2]
         }
         
-        testAsync "Registering producer to the same topic returns same task" {
+        testTask "Registering producer to the same topic returns same task" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -96,7 +96,7 @@ let tests =
             Expect.allEqual "" results.[0] results
         }
         
-        testAsync "Registering producers to multiple topics returns different tasks" {
+        testTask "Registering producers to multiple topics returns different tasks" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -126,7 +126,7 @@ let tests =
             Expect.notEqual "" results.[0] results.[1]
         }
         
-        testAsync "Ack and commit works as expected" {
+        testTask "Ack and commit works as expected" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let mutable commited = false
@@ -142,15 +142,15 @@ let tests =
             let ts = Transaction(timeout, operations, txnId)
             ts.RegisterAckOp(tcs.Task)
             let commitTask = ts.Commit()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isFalse "" commitTask.IsCompleted
             tcs.SetResult()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isTrue "" commitTask.IsCompletedSuccessfully
             Expect.isTrue "" commited
         }
         
-        testAsync "Send and commit works as expected" {
+        testTask "Send and commit works as expected" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let mutable commited = false
@@ -166,15 +166,15 @@ let tests =
             let ts = Transaction(timeout, operations, txnId)
             ts.RegisterSendOp(tcs.Task)
             let commitTask = ts.Commit()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isFalse "" commitTask.IsCompleted
             tcs.SetResult(MessageId.Latest)
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isTrue "" commitTask.IsCompletedSuccessfully
             Expect.isTrue "" commited
         }
         
-        testAsync "Ack and abort works as expected" {
+        testTask "Ack and abort works as expected" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let mutable aborted = false
@@ -190,15 +190,15 @@ let tests =
             let ts = Transaction(timeout, operations, txnId)
             ts.RegisterAckOp(tcs.Task)
             let commitTask = ts.Abort()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isFalse "" commitTask.IsCompleted
             tcs.SetResult()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isTrue "" commitTask.IsCompletedSuccessfully
             Expect.isTrue "" aborted
         }
         
-        testAsync "Send and abort works as expected" {
+        testTask "Send and abort works as expected" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let mutable aborted = false
@@ -214,15 +214,15 @@ let tests =
             let ts = Transaction(timeout, operations, txnId)
             ts.RegisterSendOp(tcs.Task)
             let commitTask = ts.Abort()
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isFalse "" commitTask.IsCompleted
             tcs.SetResult(MessageId.Latest)
-            do! Async.Sleep 40
+            do! Task.Delay 40
             Expect.isTrue "" commitTask.IsCompletedSuccessfully
             Expect.isTrue "" aborted
         }
         
-        testAsync "Can't use transaction after commit" {
+        testTask "Can't use transaction after commit" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -242,7 +242,7 @@ let tests =
             
         }
         
-        testAsync "Can't use transaction after abort" {
+        testTask "Can't use transaction after abort" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -262,7 +262,7 @@ let tests =
             
         }
         
-        testAsync "CumulativeAckConsumer is cleared after abort" {
+        testTask "CumulativeAckConsumer is cleared after abort" {
             
             let timeout = TimeSpan.FromMinutes(1.0)
             let operations =
@@ -283,7 +283,7 @@ let tests =
                     IncreaseAvailablePermits = fun num -> increased <- num
                 }
             ts.RegisterCumulativeAckConsumer(%1UL, consumerOperations)
-            do! ts.Abort() |> Async.AwaitTask
+            do! ts.Abort() 
             
             Expect.equal "" msgToClearNum increased
         }

--- a/tests/UnitTests/Internal/UnAckedMessageTrackerTests.fs
+++ b/tests/UnitTests/Internal/UnAckedMessageTrackerTests.fs
@@ -52,7 +52,7 @@ let tests =
             tracker.Close()
         }
 
-        testAsync "UnAckedMessageTracker redeliver all works" {
+        testTask "UnAckedMessageTracker redeliver all works" {
             
             let scheduler = new ManualInvokeScheduler()
             let getScheduler onTick =
@@ -75,12 +75,12 @@ let tests =
             //first two ticks just needed to get rid of 2 empty redelivery sets
             scheduler.Tick(); scheduler.Tick(); scheduler.Tick()
             
-            let! redelivered = tsc.Task |> Async.AwaitTask
+            let! redelivered = tsc.Task 
             redelivered |> Expect.equal "" 3
             tracker.Close()
         }
 
-        testAsync "UnAckedMessageTracker redeliver one works" {
+        testTask "UnAckedMessageTracker redeliver one works" {
             
             let scheduler = new ManualInvokeScheduler()
             let getScheduler onTick =
@@ -105,7 +105,7 @@ let tests =
             //first two ticks just needed to get rid of 2 empty redelivery sets
             scheduler.Tick(); scheduler.Tick(); scheduler.Tick()            
             
-            let! redelivered = tsc.Task |> Async.AwaitTask
+            let! redelivered = tsc.Task 
             redelivered |> Expect.equal "" 1
             tracker.Close()
         }


### PR DESCRIPTION
Hi, I replace testAsync to testTask. Also replaced Async.Sleep to Task.Delay and added types annotation for some let! bindings like consumer, producer and message, because task computation expression does not inference types and complier show that error "FS0072: Lookup on object of indeterminate type"