### PR TITLE
Fix seek chunked messages

### DIFF
--- a/src/Pulsar.Client.Proto/Generated.cs
+++ b/src/Pulsar.Client.Proto/Generated.cs
@@ -104,6 +104,9 @@ namespace pulsar.proto
         internal void ResetBatchSize() => __pbn__BatchSize = null;
         private int? __pbn__BatchSize;
 
+        [global::ProtoBuf.ProtoMember(7, Name = @"first_chunk_message_id")]
+        internal MessageIdData FirstChunkMessageId { get; set; }
+
     }
 
     [global::ProtoBuf.ProtoContract()]
@@ -689,6 +692,17 @@ namespace pulsar.proto
         internal void ResetSupportsBrokerEntryMetadata() => __pbn__SupportsBrokerEntryMetadata = null;
         private bool? __pbn__SupportsBrokerEntryMetadata;
 
+        [global::ProtoBuf.ProtoMember(3, Name = @"supports_partial_producer")]
+        [global::System.ComponentModel.DefaultValue(false)]
+        internal bool SupportsPartialProducer
+        {
+            get => __pbn__SupportsPartialProducer ?? false;
+            set => __pbn__SupportsPartialProducer = value;
+        }
+        internal bool ShouldSerializeSupportsPartialProducer() => __pbn__SupportsPartialProducer != null;
+        internal void ResetSupportsPartialProducer() => __pbn__SupportsPartialProducer = null;
+        private bool? __pbn__SupportsPartialProducer;
+
     }
 
     [global::ProtoBuf.ProtoContract()]
@@ -966,6 +980,19 @@ namespace pulsar.proto
 
         [global::ProtoBuf.ProtoMember(17)]
         internal KeySharedMeta keySharedMeta { get; set; }
+
+        [global::ProtoBuf.ProtoMember(18, Name = @"subscription_properties")]
+        internal global::System.Collections.Generic.List<KeyValue> SubscriptionProperties { get; } = new global::System.Collections.Generic.List<KeyValue>();
+
+        [global::ProtoBuf.ProtoMember(19, Name = @"consumer_epoch")]
+        internal ulong ConsumerEpoch
+        {
+            get => __pbn__ConsumerEpoch.GetValueOrDefault();
+            set => __pbn__ConsumerEpoch = value;
+        }
+        internal bool ShouldSerializeConsumerEpoch() => __pbn__ConsumerEpoch != null;
+        internal void ResetConsumerEpoch() => __pbn__ConsumerEpoch = null;
+        private ulong? __pbn__ConsumerEpoch;
 
         [global::ProtoBuf.ProtoContract()]
         internal enum SubType
@@ -1350,6 +1377,28 @@ namespace pulsar.proto
         internal void ResetTopicEpoch() => __pbn__TopicEpoch = null;
         private ulong? __pbn__TopicEpoch;
 
+        [global::ProtoBuf.ProtoMember(12, Name = @"txn_enabled")]
+        [global::System.ComponentModel.DefaultValue(false)]
+        internal bool TxnEnabled
+        {
+            get => __pbn__TxnEnabled ?? false;
+            set => __pbn__TxnEnabled = value;
+        }
+        internal bool ShouldSerializeTxnEnabled() => __pbn__TxnEnabled != null;
+        internal void ResetTxnEnabled() => __pbn__TxnEnabled = null;
+        private bool? __pbn__TxnEnabled;
+
+        [global::ProtoBuf.ProtoMember(13, Name = @"initial_subscription_name")]
+        [global::System.ComponentModel.DefaultValue("")]
+        internal string InitialSubscriptionName
+        {
+            get => __pbn__InitialSubscriptionName ?? "";
+            set => __pbn__InitialSubscriptionName = value;
+        }
+        internal bool ShouldSerializeInitialSubscriptionName() => __pbn__InitialSubscriptionName != null;
+        internal void ResetInitialSubscriptionName() => __pbn__InitialSubscriptionName = null;
+        private string __pbn__InitialSubscriptionName;
+
     }
 
     [global::ProtoBuf.ProtoContract()]
@@ -1509,6 +1558,16 @@ namespace pulsar.proto
 
         [global::ProtoBuf.ProtoMember(4, Name = @"ack_set")]
         internal long[] AckSets { get; set; }
+
+        [global::ProtoBuf.ProtoMember(5, Name = @"consumer_epoch")]
+        internal ulong ConsumerEpoch
+        {
+            get => __pbn__ConsumerEpoch.GetValueOrDefault();
+            set => __pbn__ConsumerEpoch = value;
+        }
+        internal bool ShouldSerializeConsumerEpoch() => __pbn__ConsumerEpoch != null;
+        internal void ResetConsumerEpoch() => __pbn__ConsumerEpoch = null;
+        private ulong? __pbn__ConsumerEpoch;
 
     }
 
@@ -1794,6 +1853,16 @@ namespace pulsar.proto
 
         [global::ProtoBuf.ProtoMember(2, Name = @"message_ids")]
         internal global::System.Collections.Generic.List<MessageIdData> MessageIds { get; } = new global::System.Collections.Generic.List<MessageIdData>();
+
+        [global::ProtoBuf.ProtoMember(3, Name = @"consumer_epoch")]
+        internal ulong ConsumerEpoch
+        {
+            get => __pbn__ConsumerEpoch.GetValueOrDefault();
+            set => __pbn__ConsumerEpoch = value;
+        }
+        internal bool ShouldSerializeConsumerEpoch() => __pbn__ConsumerEpoch != null;
+        internal void ResetConsumerEpoch() => __pbn__ConsumerEpoch = null;
+        private ulong? __pbn__ConsumerEpoch;
 
     }
 
@@ -2294,6 +2363,55 @@ namespace pulsar.proto
         internal bool ShouldSerializeSchemaVersion() => __pbn__SchemaVersion != null;
         internal void ResetSchemaVersion() => __pbn__SchemaVersion = null;
         private byte[] __pbn__SchemaVersion;
+
+    }
+
+    [global::ProtoBuf.ProtoContract()]
+    internal partial class CommandTcClientConnectRequest : global::ProtoBuf.IExtensible
+    {
+        private global::ProtoBuf.IExtension __pbn__extensionData;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+            => global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
+
+        [global::ProtoBuf.ProtoMember(1, Name = @"request_id", IsRequired = true)]
+        internal ulong RequestId { get; set; }
+
+        [global::ProtoBuf.ProtoMember(2, Name = @"tc_id", IsRequired = true)]
+        internal ulong TcId { get; set; }
+
+    }
+
+    [global::ProtoBuf.ProtoContract()]
+    internal partial class CommandTcClientConnectResponse : global::ProtoBuf.IExtensible
+    {
+        private global::ProtoBuf.IExtension __pbn__extensionData;
+        global::ProtoBuf.IExtension global::ProtoBuf.IExtensible.GetExtensionObject(bool createIfMissing)
+            => global::ProtoBuf.Extensible.GetExtensionObject(ref __pbn__extensionData, createIfMissing);
+
+        [global::ProtoBuf.ProtoMember(1, Name = @"request_id", IsRequired = true)]
+        internal ulong RequestId { get; set; }
+
+        [global::ProtoBuf.ProtoMember(2, Name = @"error")]
+        [global::System.ComponentModel.DefaultValue(ServerError.UnknownError)]
+        internal ServerError Error
+        {
+            get => __pbn__Error ?? ServerError.UnknownError;
+            set => __pbn__Error = value;
+        }
+        internal bool ShouldSerializeError() => __pbn__Error != null;
+        internal void ResetError() => __pbn__Error = null;
+        private ServerError? __pbn__Error;
+
+        [global::ProtoBuf.ProtoMember(3, Name = @"message")]
+        [global::System.ComponentModel.DefaultValue("")]
+        internal string Message
+        {
+            get => __pbn__Message ?? "";
+            set => __pbn__Message = value;
+        }
+        internal bool ShouldSerializeMessage() => __pbn__Message != null;
+        internal void ResetMessage() => __pbn__Message = null;
+        private string __pbn__Message;
 
     }
 
@@ -3088,6 +3206,12 @@ namespace pulsar.proto
         [global::ProtoBuf.ProtoMember(61)]
         internal CommandEndTxnOnSubscriptionResponse endTxnOnSubscriptionResponse { get; set; }
 
+        [global::ProtoBuf.ProtoMember(62)]
+        internal CommandTcClientConnectRequest tcClientConnectRequest { get; set; }
+
+        [global::ProtoBuf.ProtoMember(63)]
+        internal CommandTcClientConnectResponse tcClientConnectResponse { get; set; }
+
         [global::ProtoBuf.ProtoContract()]
         internal enum Type
         {
@@ -3193,6 +3317,10 @@ namespace pulsar.proto
             EndTxnOnSubscription = 60,
             [global::ProtoBuf.ProtoEnum(Name = @"END_TXN_ON_SUBSCRIPTION_RESPONSE")]
             EndTxnOnSubscriptionResponse = 61,
+            [global::ProtoBuf.ProtoEnum(Name = @"TC_CLIENT_CONNECT_REQUEST")]
+            TcClientConnectRequest = 62,
+            [global::ProtoBuf.ProtoEnum(Name = @"TC_CLIENT_CONNECT_RESPONSE")]
+            TcClientConnectResponse = 63,
         }
 
     }
@@ -3298,6 +3426,10 @@ namespace pulsar.proto
         V16 = 16,
         [global::ProtoBuf.ProtoEnum(Name = @"v17")]
         V17 = 17,
+        [global::ProtoBuf.ProtoEnum(Name = @"v18")]
+        V18 = 18,
+        [global::ProtoBuf.ProtoEnum(Name = @"v19")]
+        V19 = 19,
     }
 
     [global::ProtoBuf.ProtoContract()]

--- a/src/Pulsar.Client.Proto/PulsarApi.proto
+++ b/src/Pulsar.Client.Proto/PulsarApi.proto
@@ -61,6 +61,9 @@ message MessageIdData {
 	optional int32 batch_index = 4 [default = -1];
 	repeated int64 ack_set = 5;
 	optional int32 batch_size = 6;
+
+	// For the chunk message id, we need to specify the first chunk message id.
+	optional MessageIdData first_chunk_message_id = 7;
 }
 
 message KeyValue {
@@ -194,7 +197,7 @@ enum ServerError {
 	AuthorizationError  = 4; // Not authorized to use resource
 
 	ConsumerBusy        = 5; // Unable to subscribe/unsubscribe because
-	// other consumers are connected
+							 // other consumers are connected
 	ServiceNotReady     = 6; // Any error that requires client retry operation with a fresh lookup
 	ProducerBlockedQuotaExceededError = 7; // Unable to create producer because backlog quota exceeded
 	ProducerBlockedQuotaExceededException = 8; // Exception while creating producer because quota exceeded
@@ -220,10 +223,10 @@ enum ServerError {
 	TransactionNotFound = 24; // Transaction not found
 
 	ProducerFenced = 25; // When a producer asks and fail to get exclusive producer access,
-	// or loses the eclusive status after a reconnection, the broker will
-	// use this error to indicate that this producer is now permanently
-	// fenced. Applications are now supposed to close it and create a
-	// new producer
+						 // or loses the eclusive status after a reconnection, the broker will
+						 // use this error to indicate that this producer is now permanently
+						 // fenced. Applications are now supposed to close it and create a
+						 // new producer
 }
 
 enum AuthMethod {
@@ -248,14 +251,16 @@ enum ProtocolVersion {
 	v10 = 10;// Added proxy to broker
 	v11 = 11;// C++ consumers before this version are not correctly handling the checksum field
 	v12 = 12;// Added get topic's last messageId from broker
-	// Added CommandActiveConsumerChange
-	// Added CommandGetTopicsOfNamespace
+			 // Added CommandActiveConsumerChange
+			 // Added CommandGetTopicsOfNamespace
 	v13 = 13; // Schema-registry : added avro schema format for json
 	v14 = 14; // Add CommandAuthChallenge and CommandAuthResponse for mutual auth
-	// Added Key_Shared subscription
+			  // Added Key_Shared subscription
 	v15 = 15; // Add CommandGetOrCreateSchema and CommandGetOrCreateSchemaResponse
-	v16 = 16; // Add support for raw message metadata
+	v16 = 16; // Add support for broker entry metadata
 	v17 = 17; // Added support ack receipt
+	v18 = 18; // Add client support for broker entry metadata
+	v19 = 19; // Add CommandTcClientConnectRequest and CommandTcClientConnectResponse
 }
 
 message CommandConnect {
@@ -285,8 +290,9 @@ message CommandConnect {
 }
 
 message FeatureFlags {
-	optional bool supports_auth_refresh = 1 [default = false];
-	optional bool supports_broker_entry_metadata = 2 [default = false];
+  optional bool supports_auth_refresh = 1 [default = false];
+  optional bool supports_broker_entry_metadata = 2 [default = false];
+  optional bool supports_partial_producer = 3 [default = false];
 }
 
 message CommandConnected {
@@ -380,6 +386,11 @@ message CommandSubscribe {
 	optional uint64 start_message_rollback_duration_sec = 16 [default = 0];
 
 	optional KeySharedMeta keySharedMeta = 17;
+
+	repeated KeyValue subscription_properties = 18;
+
+	// The consumer epoch, when exclusive and failover consumer redeliver unack message will increase the epoch
+	optional uint64 consumer_epoch = 19;
 }
 
 message CommandPartitionedTopicMetadata {
@@ -481,6 +492,14 @@ message CommandProducer {
 	// leave it empty and then it will always carry the same epoch number on
 	// the subsequent reconnections.
 	optional uint64 topic_epoch = 11;
+
+	optional bool txn_enabled = 12 [default = false];
+
+	// Name of the initial subscription of the topic.
+	// If this field is not set, the initial subscription will not be created.
+	// If this field is set but the broker's `allowAutoSubscriptionCreation`
+	// is disabled, the producer will fail to be created.
+	optional string initial_subscription_name = 13;
 }
 
 message CommandSend {
@@ -517,6 +536,7 @@ message CommandMessage {
 	required MessageIdData message_id = 2;
 	optional uint32 redelivery_count  = 3 [default = 0];
 	repeated int64 ack_set = 4;
+	optional uint64 consumer_epoch = 5;
 }
 
 message CommandAck {
@@ -561,8 +581,8 @@ message CommandAckResponse {
 
 // changes on active consumer
 message CommandActiveConsumerChange {
-	required uint64 consumer_id    = 1;
-	optional bool is_active     = 2 [default = false];
+		required uint64 consumer_id    = 1;
+		optional bool is_active     = 2 [default = false];
 }
 
 message CommandFlow {
@@ -607,6 +627,7 @@ message CommandCloseConsumer {
 message CommandRedeliverUnacknowledgedMessages {
 	required uint64 consumer_id = 1;
 	repeated MessageIdData message_ids = 2;
+	optional uint64 consumer_epoch = 3;
 }
 
 message CommandSuccess {
@@ -649,52 +670,52 @@ message CommandPong {
 }
 
 message CommandConsumerStats {
-	required uint64 request_id         = 1;
-	// required string topic_name         = 2;
-	// required string subscription_name  = 3;
-	required uint64 consumer_id        = 4;
+		required uint64 request_id         = 1;
+		// required string topic_name         = 2;
+		// required string subscription_name  = 3;
+		required uint64 consumer_id        = 4;
 }
 
 message CommandConsumerStatsResponse {
-	required uint64 request_id              = 1;
-	optional ServerError error_code         = 2;
-	optional string error_message           = 3;
+		required uint64 request_id              = 1;
+		optional ServerError error_code         = 2;
+		optional string error_message           = 3;
 
-	/// Total rate of messages delivered to the consumer. msg/s
-	optional double msgRateOut                  = 4;
+		/// Total rate of messages delivered to the consumer. msg/s
+		optional double msgRateOut                  = 4;
 
-	/// Total throughput delivered to the consumer. bytes/s
-	optional double msgThroughputOut            = 5;
+		/// Total throughput delivered to the consumer. bytes/s
+		optional double msgThroughputOut            = 5;
 
-	/// Total rate of messages redelivered by this consumer. msg/s
-	optional double msgRateRedeliver            = 6;
+		/// Total rate of messages redelivered by this consumer. msg/s
+		optional double msgRateRedeliver            = 6;
 
-	/// Name of the consumer
-	optional string consumerName                = 7;
+		/// Name of the consumer
+		optional string consumerName                = 7;
 
-	/// Number of available message permits for the consumer
-	optional uint64 availablePermits            = 8;
+		/// Number of available message permits for the consumer
+		optional uint64 availablePermits            = 8;
 
-	/// Number of unacknowledged messages for the consumer
-	optional uint64 unackedMessages             = 9;
+		/// Number of unacknowledged messages for the consumer
+		optional uint64 unackedMessages             = 9;
 
-	/// Flag to verify if consumer is blocked due to reaching threshold of unacked messages
-	optional bool blockedConsumerOnUnackedMsgs  = 10;
+		/// Flag to verify if consumer is blocked due to reaching threshold of unacked messages
+		optional bool blockedConsumerOnUnackedMsgs  = 10;
 
-	/// Address of this consumer
-	optional string address                     = 11;
+		/// Address of this consumer
+		optional string address                     = 11;
 
-	/// Timestamp of connection
-	optional string connectedSince              = 12;
+		/// Timestamp of connection
+		optional string connectedSince              = 12;
 
-	/// Whether this subscription is Exclusive or Shared or Failover
-	optional string type                        = 13;
+		/// Whether this subscription is Exclusive or Shared or Failover
+		optional string type                        = 13;
 
-	/// Total rate of messages expired on this subscription. msg/s
-	optional double msgRateExpired              = 14;
+		/// Total rate of messages expired on this subscription. msg/s
+		optional double msgRateExpired              = 14;
 
-	/// Number of messages in the subscription backlog
-	optional uint64 msgBacklog                  = 15;
+		/// Number of messages in the subscription backlog
+		optional uint64 msgBacklog                  = 15;
 }
 
 message CommandGetLastMessageId {
@@ -759,6 +780,17 @@ message CommandGetOrCreateSchemaResponse {
 enum TxnAction {
 	COMMIT = 0;
 	ABORT = 1;
+}
+
+message CommandTcClientConnectRequest {
+	required uint64 request_id = 1;
+	required uint64 tc_id = 2 [default = 0];
+}
+
+message CommandTcClientConnectResponse {
+	required uint64 request_id = 1;
+	optional ServerError error  = 2;
+	optional string message     = 3;
 }
 
 message CommandNewTxn {
@@ -940,6 +972,8 @@ message BaseCommand {
 
 		END_TXN_ON_SUBSCRIPTION = 60;
 		END_TXN_ON_SUBSCRIPTION_RESPONSE = 61;
+		TC_CLIENT_CONNECT_REQUEST = 62;
+		TC_CLIENT_CONNECT_RESPONSE = 63;
 
 	}
 
@@ -1015,4 +1049,6 @@ message BaseCommand {
 	optional CommandEndTxnOnPartitionResponse endTxnOnPartitionResponse = 59;
 	optional CommandEndTxnOnSubscription endTxnOnSubscription = 60;
 	optional CommandEndTxnOnSubscriptionResponse endTxnOnSubscriptionResponse = 61;
+	optional CommandTcClientConnectRequest tcClientConnectRequest = 62;
+	optional CommandTcClientConnectResponse tcClientConnectResponse = 63;
 }

--- a/src/Pulsar.Client/Common/MessageId.fs
+++ b/src/Pulsar.Client/Common/MessageId.fs
@@ -98,7 +98,12 @@ type MessageId =
                     | (Single, Single) -> true
                     | (Batch (i, _), Batch (j, _)) -> i = j
                     | (Single, Batch (i, _)) -> i = %(-1)
-                    | (Batch (i, _), Single) -> i = %(-1)
+                    | (Batch (i, _), Single) -> i = %(-1) 
+                    &&
+                    match m.ChunkMessageIds, this.ChunkMessageIds with
+                    | Some mchunkMessageIds, Some thisChunkMessageIds when mchunkMessageIds.Length > 0 && thisChunkMessageIds.Length > 0 ->
+                        mchunkMessageIds.[0] = thisChunkMessageIds.[0] // We need to check the first chunk message id if the message is a chunkd message
+                    | _, _ -> true
             | _ ->
                 false
             

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1064,7 +1064,11 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                     let payload, seekMessageId =
                         match seekData with
                         | SeekType.Timestamp timestamp -> Commands.newSeekByTimestamp consumerId requestId timestamp, MessageId.Earliest
-                        | SeekType.MessageId messageId -> Commands.newSeekByMsgId consumerId requestId messageId, messageId
+                        | SeekType.MessageId messageId -> 
+                            match messageId.ChunkMessageIds with 
+                            | Some chunkMessageIds when chunkMessageIds.Length >0 ->
+                                    Commands.newSeekByMsgId consumerId requestId chunkMessageIds[0], chunkMessageIds[0]
+                            | _ -> Commands.newSeekByMsgId consumerId requestId messageId, messageId
                     let originSeekMessageId = duringSeek
                     duringSeek <- Some seekMessageId
                     try

--- a/tests/IntegrationTests/Chunks.fs
+++ b/tests/IntegrationTests/Chunks.fs
@@ -170,11 +170,11 @@ let tests =
             let payload = Array.zeroCreate 10_000_000
             Random().NextBytes(payload)
             
-            let msgIds = [ for i in 0 .. 9 -> 
-                            producer.NewMessage(payload)
-                            |> producer.SendAsync
-                            |> Async.AwaitTask
-                            |> Async.RunSynchronously]
+            let! (msgIds: MessageId[]) =
+                [| for i in 0 .. 9 do
+                     producer.NewMessage(payload)
+                     |> producer.SendAsync|]
+                |> Task.WhenAll
 
             for i in 0 .. 9 do
                 do! consumer.ReceiveAsync()

--- a/tests/IntegrationTests/Chunks.fs
+++ b/tests/IntegrationTests/Chunks.fs
@@ -184,8 +184,7 @@ let tests =
                 let! (msgAfterSeek : Message<byte[]>) = consumer.ReceiveAsync()
                 Expect.equal "" msgIds.[i] msgAfterSeek.MessageId
         
-            do! consumer.UnsubscribeAsync() 
-            do! Task.Delay 100
+            do! consumer.UnsubscribeAsync()
             Log.Debug("Ended Seek chunk messages and receive correctly")
         }
     ]

--- a/tests/UnitTests/Common/MessageTests.fs
+++ b/tests/UnitTests/Common/MessageTests.fs
@@ -56,4 +56,12 @@ let tests =
             Expect.equal "" msgId1 msgId4
             Expect.equal "" msgId1 msgId5
         }
+
+        test "Serialization works correctly" {
+            let msgId = { LedgerId = %1L; EntryId = %1L; Type = Single; Partition = 1;  TopicName = %""; 
+                ChunkMessageIds = Some([| { LedgerId = %0L; EntryId = %0L; Type = Single; Partition = 0;  TopicName = %""; ChunkMessageIds = None} |]) }
+            let msgIdData = msgId.ToByteArray()
+            let deserialized = MessageId.FromByteArray msgIdData
+            Expect.equal "" msgId deserialized
+        }
     ]


### PR DESCRIPTION
## Motivation

This is the implementation of https://github.com/apache/pulsar/issues/12402.

Currently, when we send chunked messages, the producer returns the message-id of the last chunk. This can cause some problems. For example, when we use this message-id to seek, it will cause the consumer to consume from the position of the last chunk, and the consumer will mistakenly think that the previous chunks are lost and choose to skip the current message. If we use the inclusive seek, the consumer may skip the first message, which brings the wrong behavior.

Here is the simple code(in java) used to demonstrate the problem.

```java
var msgId = producer.send(...); // eg. return 0:1:-1

var otherMsg = producer.send(...); // return 0:2:-1

consumer.seek(msgId); // inclusive seek

var receiveMsgId = consumer.receive().getMessageId(); // it may skip the
first message and return like 0:2:-1

Assert.assertEquals(msgId, receiveMsgId); // fail
```

For more context, please see [PIP-107](https://github.com/apache/pulsar/issues/12402)

And I find that f# client has already stored all chunk message ids in MessageIds.chunkMessageIds. We can use this field to implement the ChunkMessageId feature like in java. 

There is still work left in this PR to serialize the ChunkMessageId. To be consistent with the behavior of the Java client, when we serialize and deserialize messageIDs or compare messageId, the comparison for chunkMessageIds only needs to compare the message id of the first chunk if the message is a chunked message. Like below:

```fsharp
match m.ChunkMessageIds, this.ChunkMessageIds with
| Some mchunkMessageIds, Some thisChunkMessageIds when mchunkMessageIds.Length > 0 && thisChunkMessageIds.Length > 0 ->
                        mchunkMessageIds.[0] = thisChunkMessageIds.[0] // We need to check the first chunk message id if the message is a chunkd message
| _, _ -> true
```

We need to update the pulsar proto file before proceeding with the rest of the work. What is the correct way to generate the code for the proto? I found that the code I generated using `protoc` is very different from the existing generated code. Are the parameters not set correctly?

Update: The serialization for the chunk message id is added. This PR is ready for review.

## Modification

* Fix consumer inclusive seek for chunked message
* Add compare for the first chunk message id in MessageId.