### PR TITLE
Fix the startMessageId can't be respected as the ChunkMessageID

### DIFF
--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -85,7 +85,14 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
     let subscribeTimeout = DateTime.Now.Add(clientConfig.OperationTimeout)
     let mutable hasReachedEndOfTopic = false
     let mutable avalablePermits = 0
-    let mutable startMessageId = startMessageId
+    let mutable startMessageId =
+        match startMessageId with
+        | Some startMsgId ->
+            match startMsgId.ChunkMessageIds with
+            | Some chunkMessageIds when chunkMessageIds.Length > 0 ->
+                Some(chunkMessageIds[0])
+            | _ -> Some(startMsgId)
+        | None -> None
     let mutable lastMessageIdInBroker = MessageId.Earliest
     let mutable lastDequeuedMessageId = MessageId.Earliest
     let mutable duringSeek = None

--- a/tests/IntegrationTests/Chunks.fs
+++ b/tests/IntegrationTests/Chunks.fs
@@ -185,6 +185,17 @@ let tests =
                 Expect.equal "" msgIds.[i] msgAfterSeek.MessageId
         
             do! consumer.UnsubscribeAsync()
+            
+            let! (reader :  IReader<byte[]>) =
+                client.NewReader()
+                    .Topic(topicName)
+                    .StartMessageIdInclusive()
+                    .StartMessageId(msgIds.[1])
+                    .CreateAsync()
+                    
+            let! (readMsg : Message<byte[]>) = reader.ReadNextAsync()
+            Expect.equal "" msgIds.[1] readMsg.MessageId      
+            
             Log.Debug("Ended Seek chunk messages and receive correctly")
         }
     ]


### PR DESCRIPTION
Signed-off-by: Zike Yang <zike@apache.org>

### Motivation

This is the same problem as when the consumer inclusive seeks the chunked message.

It's the same fix as in the java client: https://github.com/apache/pulsar/pull/16154

See more detail in [PIP-107](https://github.com/apache/pulsar/issues/12402)

### Modifications

* Use the first chunk message id as the startMessageId when creating the consumer/reader.