### PR TITLE
Fix client version not shown in topic stats

### DIFF
--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -116,7 +116,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
                 initialConnectionTsc: TaskCompletionSource<ClientCnx>,
                 unregisterClientCnx: Broker -> unit) as this =
 
-    let clientVersion = "Pulsar.Client v" + Assembly.GetExecutingAssembly().GetName().Version.ToString()
+    let clientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()
     let protocolVersion =
         ProtocolVersion.GetValues(typeof<ProtocolVersion>)
         :?> ProtocolVersion[]


### PR DESCRIPTION
Currently, the client version is set to `Pulsar.Client 2.11.0.0`. But the pulsar broker will ignore this version because it contains a space. See here: https://github.com/apache/pulsar/blob/ea6641e3e51d7681670fea111cbac34080036e1a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java#L701. Therefore, we cannot get the pulsar client version from the topic stats.

This PR changes the version to like `2.11.0.0` without `Pulsar.Client` and the prefix `v` to make it consistent with the java client version like `2.11.0`. After this PR gets merged, we can see the client version in the topic stats:
```
➜  apache-pulsar-2.9.2.18 bin/pulsar-admin topics stats cs-topic
{
...
  "publishers" : [ {
...
    "clientVersion" : "2.11.0.0"
  } ],
...
      "consumers" : [ {
...
        "clientVersion" : "2.11.0.0"
      } ],
...
  },
  "replication" : { },
  "deduplicationStatus" : "Disabled",
  "nonContiguousDeletedMessagesRanges" : 0,
  "nonContiguousDeletedMessagesRangesSerializedSize" : 0,
  "compaction" : {
    "lastCompactionRemovedEventCount" : 0,
    "lastCompactionSucceedTimestamp" : 0,
    "lastCompactionFailedTimestamp" : 0,
    "lastCompactionDurationTimeInMills" : 0
  }
}
```