### PR TITLE
Add a missing mapping between Pulsar AuthChallenge command and its ha…

### DIFF
--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -397,6 +397,8 @@ and internal ClientCnx (config: PulsarClientConfiguration,
             Ok (XCommandAddSubscriptionToTxnResponse command.addSubscriptionToTxnResponse)
         | BaseCommand.Type.EndTxnResponse ->
             Ok (XCommandEndTxnResponse command.endTxnResponse)
+        | BaseCommand.Type.AuthChallenge ->
+            Ok (XCommandAuthChallenge command.authChallenge)
         | BaseCommand.Type.Error ->
             Ok (XCommandError command.Error)
         | unknownType ->


### PR DESCRIPTION
Hello,
I noticed that the Pulsar AuthChallenge command is not mapped to its handler, possibly just a typo?

Pulsar sends AuthChallenge command 1 minute before the Auth token expiration. Response should contain the new token.

Once mapped, the existing handler seems to work fine. Otherwise, the command is ignored, and Pulsar drops the connection when token expires. Tested manually with Token authentication.

Regards,
Leo.