### PR TITLE
expose the connection state to consumer and producer interface #239

### DIFF
--- a/src/Pulsar.Client/Api/IConsumer.fs
+++ b/src/Pulsar.Client/Api/IConsumer.fs
@@ -77,3 +77,5 @@ type IConsumer<'T> =
     abstract member ReconsumeLaterCumulativeAsync: message:Message<'T> * deliverAt:TimeStamp -> Task<unit>
     /// The last disconnected timestamp of the consumer    abstract member LastDisconnected: DateTime
     abstract member LastDisconnectedTimestamp: TimeStamp
+    /// Return true if the consumer is connected to the broker
+    abstract member IsConnected: bool

--- a/src/Pulsar.Client/Api/IProducer.fs
+++ b/src/Pulsar.Client/Api/IProducer.fs
@@ -73,3 +73,5 @@ type IProducer<'T> =
     abstract member Name: string
     /// The last disconnected timestamp of the producer
     abstract member LastDisconnectedTimestamp: TimeStamp
+    /// Return true if the consumer is connected to the broker
+    abstract member IsConnected: bool

--- a/src/Pulsar.Client/Api/IReader.fs
+++ b/src/Pulsar.Client/Api/IReader.fs
@@ -24,3 +24,5 @@ type IReader<'T> =
     abstract member HasMessageAvailableAsync: unit -> Task<bool>
     /// Get a topic for the reader
     abstract member Topic: string
+    /// Return true if the reader is connected to the broker
+    abstract member IsConnected: bool

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1664,6 +1664,11 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
 
         member this.LastDisconnectedTimestamp =
             connectionHandler.LastDisconnectedTimestamp
+            
+        member this.IsConnected =
+            match connectionHandler.ConnectionState with
+                | Ready _ -> true
+                | _ -> false
 
 
     interface IAsyncDisposable with

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1667,8 +1667,8 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
             
         member this.IsConnected =
             match connectionHandler.ConnectionState with
-                | Ready _ -> true
-                | _ -> false
+            | Ready _ -> true
+            | _ -> false
 
 
     interface IAsyncDisposable with

--- a/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
@@ -812,9 +812,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
 
                 Log.Logger.LogDebug("{0} IsConnected", prefix)
                 consumers
-                |> Seq.map (fun (KeyValue(_, (consumer, _))) -> consumer.IsConnected)
-                |> Seq.contains(false)
-                |> not
+                |> Seq.forall (fun (KeyValue(_, (consumer, _))) -> consumer.IsConnected)
                 |> channel.SetResult
 
             | Seek (seekData, channel) ->

--- a/src/Pulsar.Client/Internal/MultiTopicsReaderImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsReaderImpl.fs
@@ -87,6 +87,9 @@ type internal MultiTopicsReaderImpl<'T> private (readerConfig: ReaderConfigurati
         member this.Topic with get() =
             castedConsumer.Topic
 
+        member this.IsConnected with get() =
+            castedConsumer.IsConnected
+
     interface IAsyncDisposable with
 
         member this.DisposeAsync() =

--- a/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
@@ -22,6 +22,7 @@ type internal PartitionedProducerMessage =
     | TickTime
     | GetStats of TaskCompletionSource<ProducerStats>
     | LastDisconnectedTimestamp of TaskCompletionSource<TimeStamp>
+    | IsConnected of TaskCompletionSource<bool>
 
 type internal PartitionedConnectionState =
     | Uninitialized
@@ -197,6 +198,15 @@ type internal PartitionedProducerImpl<'T> private (producerConfig: ProducerConfi
                 |> Seq.max
                 |> channel.SetResult
 
+            | IsConnected channel ->
+
+                Log.Logger.LogDebug("{0} IsConnected", prefix)
+                producers
+                |> Seq.map (fun producer -> producer.IsConnected)
+                |> Seq.contains(false)
+                |> not
+                |> channel.SetResult
+                
             | Close channel ->
 
                 match this.ConnectionState with
@@ -374,6 +384,8 @@ type internal PartitionedProducerImpl<'T> private (producerConfig: ProducerConfi
         member this.GetStatsAsync() = postAndAsyncReply mb GetStats
 
         member this.LastDisconnectedTimestamp = (postAndAsyncReply mb LastDisconnectedTimestamp).Result
+            
+        member this.IsConnected = (postAndAsyncReply mb IsConnected).Result
 
 
     interface IAsyncDisposable with

--- a/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
@@ -202,9 +202,7 @@ type internal PartitionedProducerImpl<'T> private (producerConfig: ProducerConfi
 
                 Log.Logger.LogDebug("{0} IsConnected", prefix)
                 producers
-                |> Seq.map (fun producer -> producer.IsConnected)
-                |> Seq.contains(false)
-                |> not
+                |> Seq.forall (fun producer -> producer.IsConnected)
                 |> channel.SetResult
                 
             | Close channel ->

--- a/src/Pulsar.Client/Internal/ProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/ProducerImpl.fs
@@ -907,8 +907,8 @@ type internal ProducerImpl<'T> private (producerConfig: ProducerConfiguration, c
             connectionHandler.LastDisconnectedTimestamp
         member this.IsConnected =
             match connectionHandler.ConnectionState with
-                | Ready _ -> true
-                | _ -> false
+            | Ready _ -> true
+            | _ -> false
 
     interface IAsyncDisposable with
 

--- a/src/Pulsar.Client/Internal/ProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/ProducerImpl.fs
@@ -905,6 +905,10 @@ type internal ProducerImpl<'T> private (producerConfig: ProducerConfiguration, c
 
         member this.LastDisconnectedTimestamp =
             connectionHandler.LastDisconnectedTimestamp
+        member this.IsConnected =
+            match connectionHandler.ConnectionState with
+                | Ready _ -> true
+                | _ -> false
 
     interface IAsyncDisposable with
 

--- a/src/Pulsar.Client/Internal/ReaderImpl.fs
+++ b/src/Pulsar.Client/Internal/ReaderImpl.fs
@@ -93,6 +93,9 @@ type internal ReaderImpl<'T> private (readerConfig: ReaderConfiguration, clientC
         member this.Topic with get() =
             castedConsumer.Topic
 
+        member this.IsConnected with get() =
+            castedConsumer.IsConnected
+
     interface IAsyncDisposable with
 
         member this.DisposeAsync() =


### PR DESCRIPTION
Hi @Lanayx,

here is my attempt for exposing the `IsConnected`. 
For the `MultiTopicsConsumerImpl` and the `PartitionedProducerImpl` I've assumed that it will be return `true` just when all Topics are connected and ready.
I've tested it localy it with the `MultiTopicsConsumerImpl` and the property switched es expected.
please give me feedback if it fits to your expectation.

Thanks
Erik