### PR TITLE
Fix typos in MultiTopic integration tests

### DIFF
--- a/tests/IntegrationTests/MultiTopic.fs
+++ b/tests/IntegrationTests/MultiTopic.fs
@@ -33,7 +33,7 @@ let tests =
 
             let! producer2 =
                 client.NewProducer()
-                    .Topic(topicName1)
+                    .Topic(topicName2)
                     .ProducerName(name + "2")
                     .EnableBatching(false)
                     .CreateAsync()
@@ -93,7 +93,7 @@ let tests =
 
             let! producer2 =
                 client.NewProducer()
-                    .Topic(topicName1)
+                    .Topic(topicName2)
                     .ProducerName(name + "2")
                     .EnableBatching(false)
                     .CreateAsync()


### PR DESCRIPTION
I noticed a couple of typos likely due to copy/paste.

_Note_: It's my first contribution, so don't hesitate to triple check 😉 