### PR TITLE
Fix docker-compose commands

### DIFF
--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -24,13 +24,13 @@ services:
       - ./scripts/wait-for-it.sh:/pulsar/bin/wait-for-it.sh
       - ./scripts/init-standalone.sh:/pulsar/bin/init-standalone.sh
     command: >
-      bash -c "tr -d '\\r' < bin/init-standalone.sh > bin/init-standalone-fixed.sh &&
-               tr -d '\\r' < bin/wait-for-it.sh > bin/wait-for-it-fixed.sh &&
-               chmod u+x bin/wait-for-it-fixed.sh &&
-               chmod u+x bin/init-standalone-fixed.sh &&
-               bin/wait-for-it-fixed.sh standalone:8080 -t 120 &&
-               bin/wait-for-it-fixed.sh standalone:2181 -t 120 &&
-               bin/init-standalone-fixed.sh"
+      bash -c "tr -d '\\r' < bin/init-standalone.sh > /tmp/init-standalone-fixed.sh &&
+               tr -d '\\r' < bin/wait-for-it.sh > /tmp/wait-for-it-fixed.sh &&
+               chmod u+x /tmp/wait-for-it-fixed.sh &&
+               chmod u+x /tmp/init-standalone-fixed.sh &&
+               /tmp/wait-for-it-fixed.sh standalone:8080 -t 120 &&
+               /tmp/wait-for-it-fixed.sh standalone:2181 -t 120 &&
+               /tmp/init-standalone-fixed.sh"
     environment:
       webServiceUrl: http://standalone:8080/
 
@@ -67,12 +67,12 @@ services:
       - ./scripts/wait-for-it.sh:/pulsar/bin/wait-for-it.sh
       - ./scripts/init-standalone-tls.sh:/pulsar/bin/init-standalone-tls.sh
     command: >
-      bash -c "tr -d '\\r' < bin/init-standalone-tls.sh > bin/init-standalone-tls-fixed.sh &&
-               tr -d '\\r' < bin/wait-for-it.sh > bin/wait-for-it-fixed.sh &&
-               chmod u+x bin/wait-for-it-fixed.sh &&
-               chmod u+x bin/init-standalone-tls-fixed.sh &&
-               bin/wait-for-it-fixed.sh standaloneTls:8443 -t 120 &&
-               bin/init-standalone-tls-fixed.sh"
+      bash -c "tr -d '\\r' < bin/init-standalone-tls.sh > /tmp/init-standalone-tls-fixed.sh &&
+               tr -d '\\r' < bin/wait-for-it.sh > /tmp/wait-for-it-fixed.sh &&
+               chmod u+x /tmp/wait-for-it-fixed.sh &&
+               chmod u+x /tmp/init-standalone-tls-fixed.sh &&
+               /tmp/wait-for-it-fixed.sh standaloneTls:8443 -t 120 &&
+               /tmp/init-standalone-tls-fixed.sh"
     environment:
       webServiceUrl: https://standaloneTls:8443/
       authPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls


### PR DESCRIPTION
Move generated files to `tmp` folder to avoid future issues. The user running these commands won't be able to create them in the `/pulsar/bin` folder in the future versions of Docker.