### PR TITLE
Ensure all connections are closed regardless of exception

### DIFF
--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -808,7 +808,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
             let mutable continueLooping = true
             let reader = connection.Input
 
-            try                
+            try
                 while continueLooping do
                     let! result = reader.ReadAsync(socketReadCancellationTokenSource.Token)
                     let buffer = result.Buffer
@@ -840,6 +840,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
                     if initialConnectionTsc.TrySetException(ConnectException("Unable to initiate connection")) then
                         Log.Logger.LogWarning("{0} New connection was aborted", prefix)
                     Log.Logger.LogWarning(ex, "{0} Socket was disconnected exceptionally while reading", prefix)
+            
             post operationsMb ChannelInactive
             Log.Logger.LogDebug("{0} readSocket stopped", prefix)
         } :> Task

--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -840,8 +840,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
                     if initialConnectionTsc.TrySetException(ConnectException("Unable to initiate connection")) then
                         Log.Logger.LogWarning("{0} New connection was aborted", prefix)
                     Log.Logger.LogWarning(ex, "{0} Socket was disconnected exceptionally while reading", prefix)
-            
-            post operationsMb ChannelInactive
+                post operationsMb ChannelInactive
             Log.Logger.LogDebug("{0} readSocket stopped", prefix)
         } :> Task
 

--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -808,42 +808,40 @@ and internal ClientCnx (config: PulsarClientConfiguration,
             let mutable continueLooping = true
             let reader = connection.Input
 
-            try
-                try
-                    while continueLooping do
-                        let! result = reader.ReadAsync(socketReadCancellationTokenSource.Token)
-                        let buffer = result.Buffer
-                        if result.IsCompleted then
-                            if initialConnectionTsc.TrySetException(ConnectException("Unable to initiate connection")) then
-                                Log.Logger.LogWarning("{0} New connection was aborted", prefix)
-                            Log.Logger.LogWarning("{0} Socket was disconnected normally while reading", prefix)
-                            post operationsMb ChannelInactive
-                            continueLooping <- false
-                        else
-                            match tryParse buffer with
-                            | Result.Ok xcmd, consumed ->
-                                handleCommand xcmd
-                                reader.AdvanceTo consumed
-                            | Result.Error IncompleteCommand, _ ->
-                                Log.Logger.LogDebug("{0} IncompleteCommand received", prefix)
-                                reader.AdvanceTo(buffer.Start, buffer.End)
-                            | Result.Error (CorruptedCommand ex), consumed ->
-                                Log.Logger.LogError(ex, "{0} Ignoring corrupted command.", prefix)
-                                reader.AdvanceTo consumed
-                            | Result.Error (UnknownCommandType unknownType), consumed ->
-                                Log.Logger.LogError("{0} UnknownCommandType {1}, ignoring message", prefix, unknownType)
-                                reader.AdvanceTo consumed
-                with Flatten ex ->
-                    match ex with
-                    | :? OperationCanceledException ->
-                        Log.Logger.LogInformation("{0} Socket read was cancelled", prefix)
-                    | _ ->
+            try                
+                while continueLooping do
+                    let! result = reader.ReadAsync(socketReadCancellationTokenSource.Token)
+                    let buffer = result.Buffer
+                    if result.IsCompleted then
                         if initialConnectionTsc.TrySetException(ConnectException("Unable to initiate connection")) then
                             Log.Logger.LogWarning("{0} New connection was aborted", prefix)
-                        Log.Logger.LogWarning(ex, "{0} Socket was disconnected exceptionally while reading", prefix)
-            finally
-                post operationsMb ChannelInactive
-                Log.Logger.LogDebug("{0} readSocket stopped", prefix)
+                        Log.Logger.LogWarning("{0} Socket was disconnected normally while reading", prefix)
+                        post operationsMb ChannelInactive
+                        continueLooping <- false
+                    else
+                        match tryParse buffer with
+                        | Result.Ok xcmd, consumed ->
+                            handleCommand xcmd
+                            reader.AdvanceTo consumed
+                        | Result.Error IncompleteCommand, _ ->
+                            Log.Logger.LogDebug("{0} IncompleteCommand received", prefix)
+                            reader.AdvanceTo(buffer.Start, buffer.End)
+                        | Result.Error (CorruptedCommand ex), consumed ->
+                            Log.Logger.LogError(ex, "{0} Ignoring corrupted command.", prefix)
+                            reader.AdvanceTo consumed
+                        | Result.Error (UnknownCommandType unknownType), consumed ->
+                            Log.Logger.LogError("{0} UnknownCommandType {1}, ignoring message", prefix, unknownType)
+                            reader.AdvanceTo consumed
+            with Flatten ex ->
+                match ex with
+                | :? OperationCanceledException ->
+                    Log.Logger.LogInformation("{0} Socket read was cancelled", prefix)
+                | _ ->
+                    if initialConnectionTsc.TrySetException(ConnectException("Unable to initiate connection")) then
+                        Log.Logger.LogWarning("{0} New connection was aborted", prefix)
+                    Log.Logger.LogWarning(ex, "{0} Socket was disconnected exceptionally while reading", prefix)
+            post operationsMb ChannelInactive
+            Log.Logger.LogDebug("{0} readSocket stopped", prefix)
         } :> Task
 
     do startRequestTimeoutTimer()


### PR DESCRIPTION
Hello, 
With some recent changes made that support various types of exceptions, including cancellation, it turned out that some connections were not being closed leading to a leak of connections. 
The solution is to add a nested try...finally code block to ensure that connections are always closed for all possible exceptions.