### PR TITLE
Decompressing with Zstd set bufferSizePrecheck flag to false

### DIFF
--- a/src/Pulsar.Client/Internal/Compression.fs
+++ b/src/Pulsar.Client/Internal/Compression.fs
@@ -1,4 +1,4 @@
-﻿namespace Pulsar.Client.Internal
+namespace Pulsar.Client.Internal
 
 open System
 open System.Buffers
@@ -127,7 +127,7 @@ module internal CompressionCodec =
                 let zstdDecompressor = new Decompressor()
                 try
                     let sourceSpan = payload.ToArray().AsSpan()
-                    zstdDecompressor.Unwrap(sourceSpan, target) |> ignore
+                    zstdDecompressor.Unwrap(sourceSpan, target, false) |> ignore
                     let ms = MemoryStreamManager.GetStream(null, uncompressedSize)
                     ms.Write(target, 0, uncompressedSize)
                     ms

--- a/tests/UnitTests/Internal/CompressionCodecTests.fs
+++ b/tests/UnitTests/Internal/CompressionCodecTests.fs
@@ -82,15 +82,15 @@ let tests =
         }
 
         test "Zstd should decode content with non specififed size in the compressed payload" {
-          //The compressed string  above has been compressed with zstd using https://www.npmjs.com/package/zstd-codec
-          //It seems this does not specify the the decompressed size in the payload
-          //The raw string has been built in JS like so and then compressed afterwards.
-          //const bytes = 1024 * 1024 * 2 + 1000
-          //let str = "";
-          //while (str.length < bytes) {
-          //   str += "hello world lorem ipsum"
-          //}
+          // The compressed string above has been compressed with zstd using this library: https://www.npmjs.com/package/zstd-codec@0.1.4
+          // It seems this library does not specify the decompressed size in the payload.
           //
+          // The raw string has been built in JS with the snippet below and then compressed afterwards.
+          // const bytes = 1024 * 1024 * 2 + 1000
+          // let str = "";
+          // while (str.length < bytes)
+          //   str += "hello world lorem ipsum"
+
           let uncompressedSize = (1024 * 1024 * 2 + 1000)
           let codec = CompressionType.ZStd |> createCodec
           let ms = new MemoryStream(helloWorldZstdWithoutDecompressedContentSizeInPayload, 0, helloWorldZstdWithoutDecompressedContentSizeInPayload.Length, true, true)

--- a/tests/UnitTests/Internal/CompressionCodecTests.fs
+++ b/tests/UnitTests/Internal/CompressionCodecTests.fs
@@ -83,7 +83,7 @@ let tests =
 
         test "Zstd should decode content with non specififed size in the compressed payload" {
           //The compressed string  above has been compressed with zstd using https://www.npmjs.com/package/zstd-codec
-          //It seems this does not specify the the decompressed size inthe payload
+          //It seems this does not specify the the decompressed size in the payload
           //The raw string has been built in JS like so and then compressed afterwards.
           //const bytes = 1024 * 1024 * 2 + 1000
           //let str = "";


### PR DESCRIPTION
Closes issue https://github.com/fsprojects/pulsar-client-dotnet/issues/257 whichs contains more information.

By calling the ZstdNet unwrap method with false for `bufferSizePrecheck` messages with Zstd compressed data that does not contain the decompressed size in the payload will still work.

A test case has been added that validates it if the removal of the flag is done at some point or switch to excplit true.

We are using version `3.3.0` and would really love if it is feasible to get it bumped in patch for that one :)

![image](https://github.com/fsprojects/pulsar-client-dotnet/assets/7819014/3d1667fd-ae9b-4485-aff3-2d7ef3ebecc2)
