### PR TITLE
Add support for setting `replicateSubscriptionState` for the subscription

### DIFF
--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -78,6 +78,7 @@ type ConsumerConfiguration<'T> =
         MaxPendingChunkedMessage: int
         AutoAckOldestChunkedMessageOnQueueFull: bool
         ExpireTimeOfIncompleteChunkedMessage: TimeSpan
+        ReplicateSubscriptionState: bool
     }
     member this.SingleTopic with get() = this.Topics |> Seq.head
     static member Default =
@@ -112,6 +113,7 @@ type ConsumerConfiguration<'T> =
             MaxPendingChunkedMessage = 10
             AutoAckOldestChunkedMessageOnQueueFull = false
             ExpireTimeOfIncompleteChunkedMessage = TimeSpan.FromSeconds(60.0)
+            ReplicateSubscriptionState = false 
         }
 
 type ProducerConfiguration =

--- a/src/Pulsar.Client/Api/ConsumerBuilder.fs
+++ b/src/Pulsar.Client/Api/ConsumerBuilder.fs
@@ -261,6 +261,11 @@ type ConsumerBuilder<'T> private (createConsumerAsync, createProducerAsync, conf
         { config with
             ConsumerCryptoFailureAction = action }
         |> this.With
+        
+    member this.ReplicateSubscriptionState replicateSubscriptionState =
+        { config with
+            ReplicateSubscriptionState = replicateSubscriptionState }
+        |> this.With        
     
     member this.SubscribeAsync(): Task<IConsumer<'T>> =
         createConsumerAsync(verify config, schema, consumerInterceptors)

--- a/src/Pulsar.Client/Common/Commands.fs
+++ b/src/Pulsar.Client/Common/Commands.fs
@@ -256,7 +256,8 @@ let newGetTopicsOfNamespaceRequest (ns : NamespaceName) (requestId : RequestId) 
 let newSubscribe (topicName: CompleteTopicName) (subscription: SubscriptionName) (consumerId: ConsumerId) (requestId: RequestId)
     (consumerName: string) (subscriptionType: SubscriptionType) (subscriptionInitialPosition: SubscriptionInitialPosition)
     (readCompacted: bool) (startMessageId: MessageIdData) (durable: bool) (startMessageRollbackDuration: TimeSpan)
-    (createTopicIfDoesNotExist: bool) (keySharedPolicy: KeySharedPolicy option) (schemaInfo: SchemaInfo) (priorityLevel: PriorityLevel) =
+    (createTopicIfDoesNotExist: bool) (keySharedPolicy: KeySharedPolicy option) (schemaInfo: SchemaInfo) (priorityLevel: PriorityLevel)
+    (replicateSubscriptionState: bool)=
     let schema = getProtoSchema schemaInfo
     let subType =
         match subscriptionType with
@@ -272,7 +273,8 @@ let newSubscribe (topicName: CompleteTopicName) (subscription: SubscriptionName)
         | _ -> failwith "Unknown initialPosition type"
     let request = CommandSubscribe(Topic = %topicName, Subscription = %subscription, subType = subType, ConsumerId = %consumerId,
                     ConsumerName = consumerName, RequestId = %requestId, initialPosition = initialPosition, ReadCompacted = readCompacted,
-                    StartMessageId = startMessageId, Durable = durable, ForceTopicCreation = createTopicIfDoesNotExist, PriorityLevel = %priorityLevel)
+                    StartMessageId = startMessageId, Durable = durable, ForceTopicCreation = createTopicIfDoesNotExist, PriorityLevel = %priorityLevel,
+                    ReplicateSubscriptionState = replicateSubscriptionState)
     match keySharedPolicy with
     | Some keySharedPolicy ->
         let meta = KeySharedMeta()

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -844,7 +844,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             consumerId requestId consumerName consumerConfig.SubscriptionType
                             consumerConfig.SubscriptionInitialPosition consumerConfig.ReadCompacted msgIdData isDurable
                             startMessageRollbackDuration createTopicIfDoesNotExist consumerConfig.KeySharedPolicy
-                            schema.SchemaInfo consumerConfig.PriorityLevel
+                            schema.SchemaInfo consumerConfig.PriorityLevel consumerConfig.ReplicateSubscriptionState
                     try
                         let! response = clientCnx.SendAndWaitForReply requestId payload
                         response |> PulsarResponseType.GetEmpty

--- a/tests/UnitTests/Common/CommandTests.fs
+++ b/tests/UnitTests/Common/CommandTests.fs
@@ -156,15 +156,16 @@ module CommandsTests =
                 let totalSize, commandSize, command =
                     serializeDeserializeSimpleCommand
                         (newSubscribe topicName %"test-subscription" consumerId requestId consumerName
-                            SubscriptionType.Exclusive SubscriptionInitialPosition.Earliest false null true TimeSpan.Zero true None (Schema.BYTES().SchemaInfo) priorityLevel)
+                            SubscriptionType.Exclusive SubscriptionInitialPosition.Earliest false null true TimeSpan.Zero true None (Schema.BYTES().SchemaInfo) priorityLevel false)
 
-                totalSize |> Expect.equal "" 70
-                commandSize |> Expect.equal "" 66
+                totalSize |> Expect.equal "" 72
+                commandSize |> Expect.equal "" 68
                 command.``type``  |> Expect.equal "" CommandType.Subscribe
                 command.Subscribe.Topic |> Expect.equal "" %topicName
                 command.Subscribe.RequestId |> Expect.equal "" %requestId
                 command.Subscribe.ConsumerId |> Expect.equal "" %consumerId
                 command.Subscribe.ConsumerName |> Expect.equal "" %consumerName
+                command.Subscribe.ReplicateSubscriptionState |> Expect.equal "" %false
             }
 
             test "newFlow should return correct frame" {

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "6650:6650"
       - "2181:2181"
+      - "8080:8080"
     command: >
       bash -c "bin/apply-config-from-env.py conf/standalone.conf &&
                bin/pulsar standalone"


### PR DESCRIPTION
## Motivation

Apply https://github.com/apache/pulsar/pull/4299 to pulsar-client-dotnet.

Introduce the `replicateSubscriptionState` setting in the ConsumerBuilder to allow subscription creation with replication enabled.

## Modification

- Add a new configuration to the ConsumerBuilder: `ReplicateSubscriptionState`


## Verification 

Include a test `Successfully creating the replicated subscription` to verify this modification. 
The consumer should be able to set the ReplicateSubscriptionState as shown below:
```
            let! (_ : IConsumer<byte[]>) =
                client.NewConsumer()
                    .Topic(topicName)
                    .ConsumerName(consumerName)
                    .SubscriptionName("replicate")
                    .SubscriptionType(SubscriptionType.Shared)
                    .ReplicateSubscriptionState(true)       //         <- Set the ReplicateSubscriptionState
                    .SubscribeAsync()
```

Once subscribed, we should be able to view the replication state for the subscription.

<img width="785" alt="image" src="https://github.com/fsprojects/pulsar-client-dotnet/assets/16974619/db077acc-dab5-4059-b263-0fcb08ecdb07">