### PR TITLE
refactor: Use Snappier library instead of Snappy.Standard

### DIFF
--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -45,7 +45,7 @@
     <PackageReference Include="protobuf-net" Version="3.2.30" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.6" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.6" />
-    <PackageReference Include="Snappy.Standard" Version="0.2.0" />
+    <PackageReference Include="Snappier" Version="1.0.0" />
     <PackageReference Include="ZstdNet" Version="1.4.5" />
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />

--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -45,7 +45,7 @@
     <PackageReference Include="protobuf-net" Version="3.2.30" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.6" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.6" />
-    <PackageReference Include="Snappier" Version="1.0.0" />
+    <PackageReference Include="Snappier" Version="1.1.6" />
     <PackageReference Include="ZstdNet" Version="1.4.5" />
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />


### PR DESCRIPTION
My organization has started using Snyk to detect vulnerabilities in repositories. It is complaining that [Snappy.Standard](https://github.com/DavidRouyer/Snappy), an 8 year old project, is using an ancient version of System.Net.Http with vulnerabilities.

This PR replaces the Snappy.Standard library with the more modern [Snappier](https://github.com/brantburnett/Snappier) library.

![image](https://github.com/fsprojects/pulsar-client-dotnet/assets/101140818/704c5354-0f39-4492-bdce-c9f8c623d72b)
