### PR TITLE
Fix issue with message payload being disposed while resending

### DIFF
--- a/src/Pulsar.Client/Common/Commands.fs
+++ b/src/Pulsar.Client/Common/Commands.fs
@@ -104,7 +104,6 @@ let private serializePayloadCommand (command : BaseCommand) (metadata: MessageMe
             try
                 return! temp.CopyToAsync(output)
             finally
-                payload.Dispose()
                 temp.Dispose()
                 binaryWriter.Dispose()
         } :> Task

--- a/src/Pulsar.Client/Common/DTO.fs
+++ b/src/Pulsar.Client/Common/DTO.fs
@@ -437,7 +437,8 @@ type internal PendingMessage<'T> =
         CreatedAt: TimeStamp
         SequenceId: SequenceId
         HighestSequenceId: SequenceId
-        Payload: SendTask
+        SendTask: SendTask
+        Payload: MemoryStream
         Callback : PendingCallback<'T>
     }
 

--- a/tests/UnitTests/Common/CommandTests.fs
+++ b/tests/UnitTests/Common/CommandTests.fs
@@ -257,4 +257,16 @@ module CommandsTests =
                 command.Seek.ConsumerId |> Expect.equal "" %consumerId
                 command.Seek.RequestId |> Expect.equal "" %requestId
             }
+            
+            test "newSend shouldn't dispose the payload" {
+                let producerId: ProducerId =  % 5UL
+                let sequenceId: SequenceId =  % 6L
+                let numMessages =  1
+                let metadata = MessageMetadata(ProducerName = "TestMe")
+                let payload = [| 1uy; 17uy; |]
+                let streamPayload = new MemoryStream(payload)
+
+                serializeDeserializePayloadCommand (newSend producerId sequenceId None numMessages metadata streamPayload) |> ignore
+                Expect.isTrue "Stream should not be disposed" streamPayload.CanRead
+            }
         ]


### PR DESCRIPTION
Fixes #281

## Motivation
When the producer resending the message, it would throw the following error:
```
[16:29:52.717 WRN] clientCnx(7, LogicalAddres Unspecified/apps-broker-0-fccfb098-3242-40e4-8d0c-2c15888ed404.usce1-whale.test.g.sn2.dev:6651) Socket was disconnected exceptionally on writing Send
System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'The stream with Id ef744d42-7ea5-4652-9175-eddbd3bd3304 and Tag  is disposed.'.
   at Microsoft.IO.RecyclableMemoryStream.ThrowDisposedException() in /_/src/RecyclableMemoryStream.cs:line 1352
   at Microsoft.IO.RecyclableMemoryStream.Seek(Int64 offset, SeekOrigin loc) in /_/src/RecyclableMemoryStream.cs:line 1164
   at Pulsar.Client.Common.Commands.serializePayloadCommand@56.Invoke(PipeWriter output) in /Users/rbt/code/pulsar-client-dotnet/src/Pulsar.Client/Common/Commands.fs:line 84
   at <StartupCode$Pulsar-Client>.$ClientCnx.clo@302-18.MoveNext() in /Users/rbt/code/pulsar-client-dotnet/src/Pulsar.Client/Internal/ClientCnx.fs:line 304
```

The root cause is that the payload would be disposed regardless of whether the send is successful. And if there is some issue when the message is inflight, like a network issue after sending the message. The producer will resend the message. But now the message payload has already been disposed, so the clientCnx will fail to process the payload MemoryStream and throw an exception.

## Modification

- Add the payload to the PendingMessage
- Avoid despoing the payload in the SendTask. And only depose the payload after deque the pendingMessage from the queue

## Verification

I added a unit test for asserting the payload won't be deposed after `serializeDeserializePayloadCommand`. But it's hard to reproduce the reconnection in the unit test.

I have also verified that this PR could fix the issue: https://github.com/fsprojects/pulsar-client-dotnet/issues/281. I tested it by forcing the reconnecting and the producer could resend the messages successfully. Otherwise without this fix, it could sometimes get stuck resending messages due to the serialization error.


