### PR TITLE
feat: Add HttpLookupService to support http serviceUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Features list (based on [Client Feature Matrix](https://github.com/apache/pulsar
         * `brew services start bookkeeper`
     1. Run commands in `/tests/IntegrationTests/commands.txt`
     1. Change `pulsarAddress` in Common.fs to point your pulsar cluster
+    1. Ensure `advertisedAddress` in broker.conf to point your pulsar cluster
     1. Ensure `public/default` namespace with default settings
     1. Ensure `public/retention` namespace with time or storage size retention configured
  - Send a Pull Request

--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -14,6 +14,7 @@ type PulsarClientConfiguration =
         StatsInterval: TimeSpan
         MaxNumberOfRejectedRequestPerConnection: int
         UseTls: bool
+        Scheme: string
         TlsHostnameVerificationEnable: bool
         TlsAllowInsecureConnection: bool
         TlsTrustCertificate: X509Certificate2
@@ -33,6 +34,7 @@ type PulsarClientConfiguration =
             StatsInterval = TimeSpan.Zero
             MaxNumberOfRejectedRequestPerConnection = 50
             UseTls = false
+            Scheme = "pulsar"
             TlsHostnameVerificationEnable = false
             TlsAllowInsecureConnection = false
             TlsTrustCertificate = null

--- a/src/Pulsar.Client/Api/PulsarClient.fs
+++ b/src/Pulsar.Client/Api/PulsarClient.fs
@@ -31,13 +31,18 @@ type internal PulsarClientMessage =
 type PulsarClient internal (config: PulsarClientConfiguration) as this =
 
     let connectionPool = ConnectionPool(config)
-    let lookupService = BinaryLookupService(config, connectionPool)
     let producers = HashSet<IAsyncDisposable>()
     let consumers = HashSet<IAsyncDisposable>()
     let schemaProviders = Dictionary<CompleteTopicName, MultiVersionSchemaInfoProvider>()
     let mutable clientState = Active
     let autoProduceStubType =  typeof<AutoProduceBytesSchemaStub>
     let autoConsumeStubType =  typeof<AutoConsumeSchemaStub>
+    let lookupService =
+        if config.Scheme = ServiceUri.HTTP_SERVICE then
+            HttpLookupService(config,connectionPool) :> ILookupService
+        else
+            BinaryLookupService(config,connectionPool) :> ILookupService
+
     let transactionClient =
         if config.EnableTransaction then
             TransactionCoordinatorClient(config, connectionPool, lookupService) |> Some

--- a/src/Pulsar.Client/Api/PulsarClientBuilder.fs
+++ b/src/Pulsar.Client/Api/PulsarClientBuilder.fs
@@ -25,7 +25,7 @@ type PulsarClientBuilder private (config: PulsarClientConfiguration) =
     member this.ServiceUrl (url: string) =
         match url |> ServiceUri.parse with
         | (Result.Ok serviceUri) ->
-            PulsarClientBuilder { config with ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls }
+            PulsarClientBuilder { config with ServiceAddresses = serviceUri.Addresses; UseTls = serviceUri.UseTls ; Scheme = serviceUri.Scheme }
         | (Result.Error message) -> invalidArg null message
 
     member this.OperationTimeout operationTimeout =

--- a/src/Pulsar.Client/Common/ServiceUri.fs
+++ b/src/Pulsar.Client/Common/ServiceUri.fs
@@ -7,16 +7,20 @@ type internal ServiceUri = {
     OriginalString : string
     Addresses : Uri list
     UseTls : bool
+    Scheme : string
 }
 
 [<RequireQualifiedAccess>]
 module internal ServiceUri =
 
-    let private BINARY_SERVICE = "pulsar"
+    let BINARY_SERVICE = "pulsar"
+    let HTTP_SERVICE = "http"
     let private SSL_SERVICE = "ssl"
 
     let private BINARY_PORT = 6650
     let private BINARY_TLS_PORT = 6651
+    let private HTTP_PORT = 8080
+    let private HTTP_TLS_PORT = 8443
 
     let private schemeGroup = "scheme"
     let private servicesGroup = "services"
@@ -25,7 +29,7 @@ module internal ServiceUri =
 
     let private pattern =
         sprintf
-            "^(?<%s>pulsar)(?:\+(?<%s>ssl))*://(?:(?<%s>[^\s/;,]+)[;,]?)+(?<%s>/.+)?$"
+            "^(?<%s>pulsar|http)(?:\+(?<%s>ssl))*://(?:(?<%s>[^\s/;,]+)[;,]?)+(?<%s>/.+)?$"
             schemeGroup
             servicesGroup
             hostsGroup
@@ -53,12 +57,14 @@ module internal ServiceUri =
                 let services = m |> getGroupCaptureValues servicesGroup
                 let hosts = m |> getGroupCaptureValues hostsGroup
                 let path = m |> getGroupValue pathGroup
-                let useTls = services |> Seq.contains SSL_SERVICE && scheme = BINARY_SERVICE
+                let useTls = services |> Seq.contains SSL_SERVICE
 
                 let createBuilder host = UriBuilder(sprintf "%s://%s%s" scheme host path)
 
                 let rewritePort (builder : UriBuilder) =
-                    if builder.Port = -1 then
+                    // UriBuilder will automatically set an 80 port when it recognizes http scheme,
+                    // so that we can only add default port when using pulsar binary protocol
+                    if scheme = BINARY_SERVICE && builder.Port = -1 then
                         if services |> Seq.contains SSL_SERVICE then
                             builder.Port <- BINARY_TLS_PORT
                         else
@@ -74,4 +80,4 @@ module internal ServiceUri =
 
                 let addresses = hosts |> Seq.map (createBuilder >> rewritePort >> dropUserInfo >> getUri) |> List.ofSeq
 
-                Ok { OriginalString = str; Addresses = addresses; UseTls = useTls }
+                Ok { OriginalString = str; Addresses = addresses; UseTls = useTls; Scheme = scheme }

--- a/src/Pulsar.Client/Internal/BinaryLookupService.fs
+++ b/src/Pulsar.Client/Internal/BinaryLookupService.fs
@@ -13,14 +13,65 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
 
     let resolveEndPoint() = endPointResolver.Resolve()
 
-    member this.GetPartitionsForTopic (topicName: TopicName) =
-        backgroundTask {
-            let! metadata = this.GetPartitionedTopicMetadata topicName.CompleteTopicName
-            if metadata.Partitions > 0 then
-                return Array.init metadata.Partitions topicName.GetPartition
-            else
-                return [| topicName |]
-        }
+    interface ILookupService with
+
+        member this.GetPartitionsForTopic (topicName: TopicName) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromMilliseconds(100.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! metadata = this.GetPartitionedTopicMetadataInner(
+                    topicName.CompleteTopicName,
+                    backoff,
+                    int config.OperationTimeout.TotalMilliseconds
+                )
+                if metadata.Partitions > 0 then
+                    return Array.init metadata.Partitions topicName.GetPartition
+                else
+                    return [| topicName |]
+            }
+
+        member this.GetPartitionedTopicMetadata topicName =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromMilliseconds(100.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetPartitionedTopicMetadataInner(topicName, backoff, int config.OperationTimeout.TotalMilliseconds)
+                return result
+            }
+
+        member this.GetBroker(topicName: CompleteTopicName) =
+            this.FindBroker(resolveEndPoint(), false, topicName, 0)
+
+        member this.GetTopicsUnderNamespace (ns : NamespaceName, isPersistent : bool) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromMilliseconds(100.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetTopicsUnderNamespaceInner(ns, backoff, int config.OperationTimeout.TotalMilliseconds, isPersistent)
+                return result
+            }
+
+        member this.GetSchema(topicName: CompleteTopicName, ?schemaVersion: SchemaVersion) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromMilliseconds(100.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetSchemaInner(topicName, schemaVersion, backoff, int config.OperationTimeout.TotalMilliseconds)
+                return result
+            }
 
     member private this.GetPartitionedTopicMetadataInner (topicName, backoff: Backoff, remainingTimeMs) =
          async {
@@ -45,21 +96,6 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
                 do! Async.Sleep nextDelay
                 return! this.GetPartitionedTopicMetadataInner(topicName, backoff, remainingTimeMs - nextDelay)
         }
-
-     member this.GetPartitionedTopicMetadata topicName =
-        backgroundTask {
-            let backoff =
-                Backoff {
-                    Initial = TimeSpan.FromMilliseconds(100.0)
-                    MandatoryStop = config.OperationTimeout + config.OperationTimeout
-                    Max = TimeSpan.FromMinutes(1.0)
-                }
-            let! result = this.GetPartitionedTopicMetadataInner(topicName, backoff, int config.OperationTimeout.TotalMilliseconds)
-            return result
-        }
-
-    member this.GetBroker(topicName: CompleteTopicName) =
-        this.FindBroker(resolveEndPoint(), false, topicName, 0)
 
     member private this.FindBroker(endpoint: DnsEndPoint, authoritative: bool, topicName: CompleteTopicName,
                                    redirectCount: int) =
@@ -112,18 +148,6 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
                 return! this.GetTopicsUnderNamespaceInner(ns, backoff, remainingTimeMs - delay, isPersistent)
         }
 
-    member this.GetTopicsUnderNamespace (ns : NamespaceName, isPersistent : bool) =
-        backgroundTask {
-            let backoff =
-                Backoff {
-                    Initial = TimeSpan.FromMilliseconds(100.0)
-                    MandatoryStop = config.OperationTimeout + config.OperationTimeout
-                    Max = TimeSpan.FromMinutes(1.0)
-                }
-            let! result = this.GetTopicsUnderNamespaceInner(ns, backoff, int config.OperationTimeout.TotalMilliseconds, isPersistent)
-            return result
-        }
-
     member private this.GetSchemaInner(topicName: CompleteTopicName, schemaVersion: SchemaVersion option,
                               backoff: Backoff, remainingTimeMs: int) =
         async {
@@ -148,15 +172,5 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
                 return! this.GetSchemaInner(topicName, schemaVersion, backoff, remainingTimeMs - delay)
         }
 
-    member this.GetSchema(topicName: CompleteTopicName, ?schemaVersion: SchemaVersion) =
-        backgroundTask {
-            let backoff =
-                Backoff {
-                    Initial = TimeSpan.FromMilliseconds(100.0)
-                    MandatoryStop = config.OperationTimeout + config.OperationTimeout
-                    Max = TimeSpan.FromMinutes(1.0)
-                }
-            let! result = this.GetSchemaInner(topicName, schemaVersion, backoff, int config.OperationTimeout.TotalMilliseconds)
-            return result
-        }
+
 

--- a/src/Pulsar.Client/Internal/ConnectionHandler.fs
+++ b/src/Pulsar.Client/Internal/ConnectionHandler.fs
@@ -27,7 +27,7 @@ type internal ConnectionState =
 
 type internal ConnectionHandler( parentPrefix: string,
                         connectionPool: ConnectionPool,
-                        lookup: BinaryLookupService,
+                        lookup: ILookupService,
                         topic: CompleteTopicName,
                         connectionOpened: uint64 -> unit,
                         connectionFailed: exn -> unit,

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -67,7 +67,7 @@ type internal ConsumerInitInfo<'T> =
 type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration,
                            topicName: TopicName, connectionPool: ConnectionPool,
                            partitionIndex: int, hasParentConsumer: bool, startMessageId: MessageId option,
-                           startMessageRollbackDuration: TimeSpan, lookup: BinaryLookupService,
+                           startMessageRollbackDuration: TimeSpan, lookup: ILookupService,
                            createTopicIfDoesNotExist: bool, schema: ISchema<'T>,
                            schemaProvider: MultiVersionSchemaInfoProvider option,
                            interceptors: ConsumerInterceptors<'T>, cleanup: ConsumerImpl<'T> -> unit) as this =
@@ -1418,7 +1418,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
 
     static member Init(consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration,
                        topicName: TopicName, connectionPool: ConnectionPool, partitionIndex: int,
-                       hasParent: bool, startMessageId: MessageId option, startMessageRollbackDuration: TimeSpan, lookup: BinaryLookupService,
+                       hasParent: bool, startMessageId: MessageId option, startMessageRollbackDuration: TimeSpan, lookup: ILookupService,
                        createTopicIfDoesNotExist: bool, schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option,
                        interceptors: ConsumerInterceptors<'T>, cleanup: ConsumerImpl<'T> -> unit) =
         backgroundTask {
@@ -1677,7 +1677,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
 and internal ZeroQueueConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration,
                            topicName: TopicName, connectionPool: ConnectionPool, partitionIndex: int,
                            hasParent: bool, startMessageId: MessageId option,
-                           lookup: BinaryLookupService,
+                           lookup: ILookupService,
                            createTopicIfDoesNotExist: bool, schema: ISchema<'T>,
                            schemaProvider: MultiVersionSchemaInfoProvider option,
                            interceptors: ConsumerInterceptors<'T>, cleanup: ConsumerImpl<'T> -> unit) as this =

--- a/src/Pulsar.Client/Internal/HttpLookupService.fs
+++ b/src/Pulsar.Client/Internal/HttpLookupService.fs
@@ -1,0 +1,230 @@
+﻿namespace Pulsar.Client.Internal
+
+open System.Collections.Generic
+open System.IO
+open System.Net.Http
+open System.Text.Json.Serialization
+open Pulsar.Client.Api
+open Pulsar.Client.Common
+open System
+open System.Net
+open FSharp.UMX
+open System.Text.Json
+open Microsoft.Extensions.Logging
+open Pulsar.Client.Schema
+
+type internal HttpLookupService (config: PulsarClientConfiguration, _connectionPool: ConnectionPool) =
+
+    let httpClient = new HttpClient(new SocketsHttpHandler(
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+        AllowAutoRedirect = true
+    ))
+    let jsonOptions = JsonSerializerOptions(
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+     )
+    do jsonOptions.Converters.Add(JsonStringEnumConverter())
+
+    interface ILookupService with
+
+        member this.GetPartitionsForTopic (topicName: TopicName) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromSeconds(5.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! metadata = this.GetPartitionedTopicMetadataInner(
+                    topicName.CompleteTopicName,
+                    backoff,
+                    int config.OperationTimeout.TotalMilliseconds
+                )
+                if metadata.Partitions > 0 then
+                    return Array.init metadata.Partitions topicName.GetPartition
+                else
+                    return [| topicName |]
+            }
+
+        member this.GetPartitionedTopicMetadata topicName =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromSeconds(5.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetPartitionedTopicMetadataInner(topicName, backoff, int config.OperationTimeout.TotalMilliseconds)
+                return result
+            }
+
+        member this.GetBroker(topicName : CompleteTopicName) =
+            this.GetBrokerInner(topicName)
+
+        member this.GetTopicsUnderNamespace (ns: NamespaceName, isPersistent: bool) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromSeconds(5.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetTopicsUnderNamespaceInner(ns, backoff, int config.OperationTimeout.TotalMilliseconds, isPersistent)
+                return result
+            }
+
+        member this.GetSchema(topicName: CompleteTopicName, ?schemaVersion: SchemaVersion) =
+            backgroundTask {
+                let backoff =
+                    Backoff {
+                        Initial = TimeSpan.FromSeconds(5.0)
+                        MandatoryStop = config.OperationTimeout + config.OperationTimeout
+                        Max = TimeSpan.FromMinutes(1.0)
+                    }
+                let! result = this.GetSchemaInner(topicName, schemaVersion, backoff, int config.OperationTimeout.TotalMilliseconds)
+                return result
+            }
+
+    //  GET /admin/v2/{topic-domain}/{tenant}/{namespace}/{topic}/partitions?checkAllowAutoCreation=true
+    member private this.GetPartitionedTopicMetadataInner (topicName: CompleteTopicName, backoff: Backoff, remainingTimeMs) =
+         async {
+            try
+                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let topic: string = %topicName
+                let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
+                let! response = randomServiceUri.AbsoluteUri + $"admin/v2/%s{topicRestPath}/partitions?checkAllowAutoCreation=true"
+                                |> httpClient.GetStreamAsync
+                                |> Async.AwaitTask
+                let brokerResponse = JsonSerializer.Deserialize<{| Partitions: int |}>(response, jsonOptions)
+                return { Partitions = brokerResponse.Partitions }
+
+            with Flatten ex ->
+                let nextDelay = Math.Min(backoff.Next(), remainingTimeMs)
+                if nextDelay <= 0 then
+                    reraize ex
+                Log.Logger.LogWarning(ex, "GetPartitionedTopicMetadata failed will retry in {0} ms", nextDelay)
+                do! Async.Sleep nextDelay
+                return! this.GetPartitionedTopicMetadataInner(topicName, backoff, remainingTimeMs - nextDelay)
+        }
+
+    //  GET /lookup/v2/topic/{topic-domain}/{tenant}/{namespace}/{topic}
+    member private this.GetBrokerInner(topicName: CompleteTopicName) =
+        backgroundTask {
+            let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+            let topic: string = %topicName
+            let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
+            let! response = httpClient.GetStreamAsync (randomServiceUri.AbsoluteUri + $"lookup/v2/topic/%s{topicRestPath}")
+            let brokerResponse = JsonSerializer.Deserialize<
+                                {|
+                                  brokerUrl : string
+                                  brokerUrlTls: string
+                                  httpUrl: string
+                                  httpUrlTls: string
+                                |}>(response, jsonOptions)
+            let uri = if config.UseTls
+                      then Uri(brokerResponse.brokerUrlTls)
+                      else Uri(brokerResponse.brokerUrl)
+            let resultEndpoint = DnsEndPoint(uri.Host, uri.Port)
+            return { LogicalAddress = LogicalAddress resultEndpoint; PhysicalAddress = PhysicalAddress resultEndpoint }
+        }
+
+    //  GET /admin/v2/namespaces/{tenant}/{namespace}/topics?mode=PERSISTENT
+    //  GET /admin/v2/namespaces/{tenant}/{namespace}/topics?mode=NON_PERSISTENT
+    member private this.GetTopicsUnderNamespaceInner (ns: NamespaceName, backoff: Backoff, remainingTimeMs: int, isPersistent: bool) =
+        async {
+            try
+                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let mode = match isPersistent with
+                            | true -> "PERSISTENT"
+                            | false -> "NON_PERSISTENT"
+                let! response = randomServiceUri.AbsoluteUri + $"admin/v2/namespaces/%s{ns.ToString()}/topics?mode=%s{mode}"
+                                |> httpClient.GetStreamAsync
+                                |> Async.AwaitTask
+                let brokerResponse = JsonSerializer.Deserialize<string seq>(response, jsonOptions)
+                return brokerResponse
+
+            with Flatten ex ->
+                let delay = Math.Min(backoff.Next(), remainingTimeMs)
+                if delay <= 0 then
+                    raise (TimeoutException "Could not getTopicsUnderNamespace within configured timeout.")
+                Log.Logger.LogWarning(ex, "GetTopicsUnderNamespace failed will retry in {0} ms", delay)
+                do! Async.Sleep delay
+                return! this.GetTopicsUnderNamespaceInner(ns, backoff, remainingTimeMs - delay, isPersistent)
+        }
+
+    //  GET /admin/v2/schemas/{tenant}/{namespace}/{topic}/schema
+    //  GET /admin/v2/schemas/{tenant}/{namespace}/{topic}/schema/{version}
+    member private this.GetSchemaInner(topicName: CompleteTopicName, schemaVersion: SchemaVersion option,
+                              backoff: Backoff, remainingTimeMs: int) =
+         async {
+            try
+                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let topic: string = %topicName
+                let topicRestPath = topic.Replace("persistent://","").Replace("non-persistent://","")
+                let path = match schemaVersion with
+                            | Some sv ->
+                                //  read 8 bytes from big endian
+                                let binaryWriter = new BinaryReader(new MemoryStream(sv.Bytes))
+                                let schemaVersionInt = binaryWriter.ReadInt64() |> int64FromBigEndian
+                                $"admin/v2/schemas/%s{topicRestPath}/schema/%d{schemaVersionInt}"
+                            | None ->
+                                $"admin/v2/schemas/%s{topicRestPath}/schema"
+                let! response = randomServiceUri.AbsoluteUri + path
+                                |> httpClient.GetStreamAsync
+                                |> Async.AwaitTask
+                let schemaResponse = JsonSerializer.Deserialize<
+                                    {|
+                                      Version : Int64
+                                      Type: SchemaType
+                                      Timestamp: Int64
+                                      Data: string
+                                      Properties: Dictionary<string, string>
+                                    |}>(response, jsonOptions)
+
+                let schemaData = match schemaResponse.Type with
+                                 | SchemaType.KEY_VALUE -> schemaResponse.Data |> this.getKeyValueSchemaBytes
+                                 | _ -> schemaResponse.Data |> System.Text.Encoding.UTF8.GetBytes
+                let schemaVersion: SchemaVersion = {
+                    Bytes = schemaResponse.Version |> BitConverter.GetBytes |> Array.rev
+                }
+                let schemaInfo: SchemaInfo = {
+                    Name = topicRestPath
+                    Type = schemaResponse.Type
+                    Properties = schemaResponse.Properties
+                    Schema = schemaData
+                }
+                let topicSchema: TopicSchema = {
+                    SchemaVersion = Some schemaVersion
+                    SchemaInfo = schemaInfo
+                }
+                return Some topicSchema
+
+            with
+                | Flatten ex ->
+                    match ex with
+                    //  When there is no topic related schema, pulsar http rest api will return a 404 exception
+                    //  In this case the request it's success, and we can return a None schema
+                    | :? HttpRequestException as ex when ex.StatusCode = Nullable HttpStatusCode.NotFound ->
+                        Log.Logger.LogWarning(ex, "No schema found for topic {0} version {1}", topicName, schemaVersion)
+                        return None
+                    | _ ->
+                        let delay = Math.Min(backoff.Next(), remainingTimeMs)
+                        if delay <= 0 then
+                            raise (TimeoutException "Could not GetSchema within configured timeout.")
+                        Log.Logger.LogWarning(ex, "GetSchema failed will retry in {0} ms", delay)
+                        do! Async.Sleep delay
+                        return! this.GetSchemaInner(topicName, schemaVersion, backoff, remainingTimeMs - delay)
+        }
+
+    //  Convert key/value schema json string to schema bytes[]
+    member private this.getKeyValueSchemaBytes(keyValueDataString: string) =
+        //  Key-value type schema `Data` field is a complicated embedded json string
+        //  so that it's difficult to deserialize the field by orm method.
+        //  Instead, we only need to extract 'key' and 'value' field and call `KeyValueSchema.GetKeyValueBytes` method.
+        let json = JsonDocument.Parse(keyValueDataString)
+        let keyString = json.RootElement.GetProperty("key").GetRawText()
+        let valueString = json.RootElement.GetProperty("value").GetRawText()
+        KeyValueSchema.GetKeyValueBytes(
+            keyString |> System.Text.Encoding.UTF8.GetBytes,
+            valueString |> System.Text.Encoding.UTF8.GetBytes
+        )
+

--- a/src/Pulsar.Client/Internal/ILookupService.fs
+++ b/src/Pulsar.Client/Internal/ILookupService.fs
@@ -1,0 +1,22 @@
+﻿namespace Pulsar.Client.Internal
+
+open Pulsar.Client.Common
+open System.Threading.Tasks
+
+type internal ILookupService =
+
+    //  Get the partitions of the topic.
+    abstract member GetPartitionsForTopic: TopicName -> Task<TopicName array>
+
+    //  Get the partitions if the topic exists. Return "{partition: n}" if a partitioned topic exists;
+    //  return "{partition: 0}" if a non-partitioned topic exists.
+    abstract member GetPartitionedTopicMetadata: CompleteTopicName -> Task<PartitionedTopicMetadata>
+
+    //  Calls broker lookup-api to get broker which serves namespace bundle that contains given topic.
+    abstract member GetBroker: CompleteTopicName -> Task<Broker>
+
+    //  Returns all topics under the given namespace.
+    abstract member GetTopicsUnderNamespace: NamespaceName * isPersistent: bool -> Task<string seq>
+
+    //  Returns current SchemaInfo for a given topic.
+    abstract member GetSchema: CompleteTopicName * ?schema: SchemaVersion -> Task<TopicSchema option>

--- a/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
@@ -74,7 +74,7 @@ type internal TopicAndConsumer<'T> =
 
 type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
                                       multiConsumerType: MultiConsumerType<'T>, startMessageId: MessageId option,
-                                      startMessageRollbackDuration: TimeSpan, lookup: BinaryLookupService,
+                                      startMessageRollbackDuration: TimeSpan, lookup: ILookupService,
                                       interceptors: ConsumerInterceptors<'T>, cleanup: MultiTopicsConsumerImpl<'T> -> unit) as this =
 
     let _this = this :> IConsumer<'T>
@@ -1029,7 +1029,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
         postAndAsyncReply mb HasMessageAvailable
 
     static member InitPartitioned(consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                                            consumerInitInfo: ConsumerInitInfo<'T>, lookup: BinaryLookupService,
+                                            consumerInitInfo: ConsumerInitInfo<'T>, lookup: ILookupService,
                                             interceptors: ConsumerInterceptors<'T>, cleanup: MultiTopicsConsumerImpl<'T> -> unit) =
         backgroundTask {
             let consumer = MultiTopicsConsumerImpl(consumerConfig, clientConfig, connectionPool, MultiConsumerType.Partitioned consumerInitInfo,
@@ -1039,7 +1039,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
         }
 
     static member InitMultiTopic(consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                                            consumerInitInfos: ConsumerInitInfo<'T>[], lookup: BinaryLookupService,
+                                            consumerInitInfos: ConsumerInitInfo<'T>[], lookup: ILookupService,
                                             interceptors: ConsumerInterceptors<'T>, cleanup: MultiTopicsConsumerImpl<'T> -> unit) =
         backgroundTask {
             let consumer = MultiTopicsConsumerImpl(consumerConfig, clientConfig, connectionPool, MultiConsumerType.MultiTopic consumerInitInfos,
@@ -1049,7 +1049,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
         }
 
     static member InitPattern(consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                                            patternInfo: PatternInfo<'T>, lookup: BinaryLookupService,
+                                            patternInfo: PatternInfo<'T>, lookup: ILookupService,
                                             interceptors: ConsumerInterceptors<'T>, cleanup: MultiTopicsConsumerImpl<'T> -> unit) =
         backgroundTask {
             let consumer = MultiTopicsConsumerImpl(consumerConfig, clientConfig, connectionPool,

--- a/src/Pulsar.Client/Internal/MultiTopicsReaderImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsReaderImpl.fs
@@ -11,7 +11,7 @@ open Pulsar.Client.Schema
 
 type internal MultiTopicsReaderImpl<'T> private (readerConfig: ReaderConfiguration, clientConfig: PulsarClientConfiguration,
                         connectionPool: ConnectionPool, consumerInitInfo: ConsumerInitInfo<'T>,
-                         schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: BinaryLookupService) =
+                         schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: ILookupService) =
     let subscriptionName =
         if String.IsNullOrEmpty readerConfig.SubscriptionRolePrefix then
             "mt/reader-" + Guid.NewGuid().ToString("N").Substring(22)
@@ -46,7 +46,7 @@ type internal MultiTopicsReaderImpl<'T> private (readerConfig: ReaderConfigurati
 
     static member internal Init(config: ReaderConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
                                 consumerInitInfo: ConsumerInitInfo<'T>,
-                                schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: BinaryLookupService) =
+                                schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: ILookupService) =
         backgroundTask {
             let reader = MultiTopicsReaderImpl(config, clientConfig, connectionPool, consumerInitInfo, schema, schemaProvider, lookup)
             do! reader.InitInternal()

--- a/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/PartitionedProducerImpl.fs
@@ -32,7 +32,7 @@ type internal PartitionedConnectionState =
     | Closed
 
 type internal PartitionedProducerImpl<'T> private (producerConfig: ProducerConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                                      numPartitions: int, lookup: BinaryLookupService, schema: ISchema<'T>,
+                                      numPartitions: int, lookup: ILookupService, schema: ISchema<'T>,
                                       interceptors: ProducerInterceptors<'T>, cleanup: PartitionedProducerImpl<'T> -> unit) as this =
     let _this = this :> IProducer<'T>
     let producerId = Generators.getNextProducerId()
@@ -327,7 +327,7 @@ type internal PartitionedProducerImpl<'T> private (producerConfig: ProducerConfi
        producerCreatedTsc.Task
 
     static member Init(producerConfig: ProducerConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                        partitions: int, lookup: BinaryLookupService, schema: ISchema<'T>,
+                        partitions: int, lookup: ILookupService, schema: ISchema<'T>,
                         interceptors:ProducerInterceptors<'T>, cleanup: PartitionedProducerImpl<'T> -> unit) =
         backgroundTask {
             let producer = PartitionedProducerImpl(producerConfig, clientConfig, connectionPool, partitions, lookup,

--- a/src/Pulsar.Client/Internal/ProducerImpl.fs
+++ b/src/Pulsar.Client/Internal/ProducerImpl.fs
@@ -42,7 +42,7 @@ type internal ProducerMessage<'T> =
     | GetStats of TaskCompletionSource<ProducerStats>
 
 type internal ProducerImpl<'T> private (producerConfig: ProducerConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                           partitionIndex: int, lookup: BinaryLookupService, schema: ISchema<'T>,
+                           partitionIndex: int, lookup: ILookupService, schema: ISchema<'T>,
                            interceptors: ProducerInterceptors<'T>, cleanup: ProducerImpl<'T> -> unit) as this =
     let _this = this :> IProducer<'T>
     let producerId = Generators.getNextProducerId()
@@ -818,7 +818,7 @@ type internal ProducerImpl<'T> private (producerConfig: ProducerConfiguration, c
        }
 
     static member Init(producerConfig: ProducerConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                       partitionIndex: int, lookup: BinaryLookupService, schema: ISchema<'T>,
+                       partitionIndex: int, lookup: ILookupService, schema: ISchema<'T>,
                        interceptors: ProducerInterceptors<'T>, cleanup: ProducerImpl<'T> -> unit) =
         backgroundTask {
             let producer = ProducerImpl(producerConfig, clientConfig, connectionPool, partitionIndex, lookup, schema,

--- a/src/Pulsar.Client/Internal/ReaderImpl.fs
+++ b/src/Pulsar.Client/Internal/ReaderImpl.fs
@@ -10,7 +10,7 @@ open Pulsar.Client.Internal
 open Pulsar.Client.Schema
 
 type internal ReaderImpl<'T> private (readerConfig: ReaderConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                         schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: BinaryLookupService) =
+                         schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: ILookupService) =
     let subscriptionName =
         if String.IsNullOrEmpty readerConfig.SubscriptionRolePrefix |> not then
             readerConfig.SubscriptionRolePrefix + "-reader-" + Guid.NewGuid().ToString("N").Substring(22)
@@ -49,7 +49,7 @@ type internal ReaderImpl<'T> private (readerConfig: ReaderConfiguration, clientC
         }
 
     static member internal Init(config: ReaderConfiguration, clientConfig: PulsarClientConfiguration, connectionPool: ConnectionPool,
-                                schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: BinaryLookupService) =
+                                schema: ISchema<'T>, schemaProvider: MultiVersionSchemaInfoProvider option, lookup: ILookupService) =
         backgroundTask {
             let reader = ReaderImpl(config, clientConfig, connectionPool, schema, schemaProvider, lookup)
             do! reader.InitInternal()

--- a/src/Pulsar.Client/Internal/TransactionMetaStoreHandler.fs
+++ b/src/Pulsar.Client/Internal/TransactionMetaStoreHandler.fs
@@ -48,7 +48,7 @@ type internal TxnRequest =
 type internal TransactionMetaStoreHandler(clientConfig: PulsarClientConfiguration,
                                     transactionCoordinatorId: TransactionCoordinatorId,
                                     completeTopicName: CompleteTopicName, connectionPool: ConnectionPool,
-                                    lookup: BinaryLookupService, transactionCoordinatorCreatedTsc: TaskCompletionSource<unit>) as this =
+                                    lookup: ILookupService, transactionCoordinatorCreatedTsc: TaskCompletionSource<unit>) as this =
     let prefix = $"tmsHandler-{transactionCoordinatorId}"
     let mutable operationsLeft = 1000
     let blockIfReachMaxPendingOps = true

--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -137,7 +137,9 @@
     <Compile Include="Internal\ClientCnx.fs" />
     <Compile Include="Internal\ConnectionPool.fs" />
     <Compile Include="Internal\EndPointResolver.fs" />
+    <Compile Include="Internal\ILookupService.fs" />
     <Compile Include="Internal\BinaryLookupService.fs" />
+    <Compile Include="Internal\HttpLookupService.fs" />
     <Compile Include="Internal\ConnectionHandler.fs" />
     <Compile Include="Internal\AcknowledgmentsGroupingTracker.fs" />
     <Compile Include="Internal\ProducerImpl.fs" />

--- a/src/Pulsar.Client/Transaction/TransactionCoordinatorClient.fs
+++ b/src/Pulsar.Client/Transaction/TransactionCoordinatorClient.fs
@@ -25,7 +25,7 @@ type internal TransactionCoordinatorMessage =
 
 type internal TransactionCoordinatorClient (clientConfig: PulsarClientConfiguration,
                                             connectionPool: ConnectionPool,
-                                            lookup: BinaryLookupService) =
+                                            lookup: ILookupService) =
 
     let DEFAULT_TXN_TTL = TimeSpan.FromSeconds(60.0)
     let prefix = "tcClient"

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -54,9 +54,16 @@ let commonClient =
         .ServiceUrl(pulsarAddress)
         .BuildAsync().Result
 
+let commonHttpLookupClient =
+    PulsarClientBuilder()
+        .ServiceUrl(pulsarHttpAddress)
+        .BuildAsync().Result
+
 let commonHttpClient = new HttpClient()
 
 let getClient() = commonClient
+
+let getHttpLookupClient() = commonHttpLookupClient
 
 let extractTimeStamp (date: DateTime) : TimeStamp =
     let mss = (date - DateTime.UnixEpoch).TotalMilliseconds |> int64

--- a/tests/IntegrationTests/HttpLookupService.fs
+++ b/tests/IntegrationTests/HttpLookupService.fs
@@ -1,0 +1,185 @@
+module Pulsar.Client.IntegrationTests.HttpLookupService
+
+open System
+open Expecto
+open Expecto.Flip
+open System.Text
+open System.Threading.Tasks
+open Pulsar.Client.Api
+open Pulsar.Client.Common
+open Serilog
+open Pulsar.Client.IntegrationTests.Common
+open System.Collections.Generic
+
+[<CLIMutable>]
+type KeySchema =
+    {
+        Name: string
+        Age: int
+    }
+
+[<CLIMutable>]
+type ValueSchema =
+    {
+        Name: int
+        Age: string
+    }
+
+[<Tests>]
+let tests =
+
+    testList "HttpLookupService" [
+
+        testTask "HttpLookupService test basic functions" {
+            Log.Debug("Started HttpLookupService test basic functions")
+            let client = getHttpLookupClient()
+            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+            let! (producer1 : IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .CreateAsync()
+            let! (producer2 : IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .EnableBatching(false)
+                    .CreateAsync()
+            let! (consumer : IConsumer<byte[]>) =
+                client.NewConsumer()
+                    .Topic(topicName)
+                    .SubscriptionName("test-subscription")
+                    .SubscribeAsync()
+            let! msg1Id = producer1.SendAsync([| 0uy |])
+            let! msg2Id = producer2.SendAsync([| 1uy |])
+            let! (msg1 : Message<byte[]>) = consumer.ReceiveAsync()
+            let! (msg2 : Message<byte[]>) = consumer.ReceiveAsync()
+            Expect.isTrue "" (msg1Id = msg1.MessageId)
+            Expect.equal "" [| 0uy |] <| msg1.GetValue()
+            Expect.isTrue "" (msg2Id = msg2.MessageId)
+            Expect.equal "" [| 1uy |] <| msg2.GetValue()
+            Log.Debug("Finished HttpLookupService test basic functions")
+        }
+
+        testTask "HttpLookupService test send/receive multiple messages" {
+            Log.Debug("Started HttpLookupService test send/receive multiple messages")
+            let client = getHttpLookupClient()
+            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+            let numberOfMessages = 100
+            let! producer =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .ProducerName("concurrent")
+                    .CreateAsync()
+            let! consumer =
+                client.NewConsumer()
+                    .Topic(topicName)
+                    .ConsumerName("concurrent")
+                    .SubscriptionName("test-subscription")
+                    .SubscribeAsync()
+            let producerTask =
+                Task.Run(fun () ->
+                    task {
+                        do! produceMessages producer numberOfMessages "concurrent"
+                    }:> Task)
+            let consumerTask =
+                Task.Run(fun () ->
+                    task {
+                        do! consumeMessages consumer numberOfMessages "concurrent"
+                    }:> Task)
+            do! Task.WhenAll(producerTask, consumerTask)
+            Log.Debug("Finished HttpLookupService test send/receive multiple messages")
+        }
+
+        testTask "HttpLookupService test GetTopicsUnderNamespace function" {
+            Log.Debug("Started HttpLookupService test GetTopicsUnderNamespace function")
+            let subscriptionName = "testPulsar"
+            let topicPattern = sprintf "persistent://public/default/%s-*" (Guid.NewGuid().ToString("N"))
+            let topic1 = topicPattern.Replace("*", "1")
+            let topic2 = topicPattern.Replace("*", "2")
+            let client = getHttpLookupClient()
+            let! (producer1 : IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topic1)
+                    .CreateAsync()
+            let! (consumer : IConsumer<byte[]>) =
+                client.NewConsumer()
+                    .TopicsPattern(topicPattern)
+                    .PatternAutoDiscoveryPeriod(TimeSpan.FromSeconds(4.0))
+                    .SubscriptionName(subscriptionName)
+                    .SubscribeAsync()
+            let send1 =
+                Task.Run(fun () ->
+                    task {
+                        for i in [1..10] do
+                            let msgStr = sprintf "Message #%i Sent to %s on %s" i topic1 (DateTime.Now.ToLongTimeString())
+                            let! _ = producer1.SendAsync(msgStr |> Encoding.UTF8.GetBytes)
+                            ()
+                    } :> Task
+                )
+            let receiveAll =
+                Task.Run(fun () ->
+                        task {
+                            for _ in [1..20] do
+                                let! message = consumer.ReceiveAsync()
+                                do! consumer.AcknowledgeAsync(message.MessageId)
+                        } :> Task
+                    )
+            do! Task.WhenAll(send1)
+            let! (producer2 : IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topic2)
+                    .CreateAsync()
+            do! Task.Delay(5000)
+            let send2 =
+                Task.Run(fun () ->
+                    task {
+                        for i in [1..10] do
+                            let msgStr = sprintf "Message #%i Sent to %s on %s" i topic2 (DateTime.Now.ToLongTimeString())
+                            let! _ = producer2.SendAsync(msgStr |> Encoding.UTF8.GetBytes)
+                            ()
+                    } :> Task
+                )
+            do! Task.WhenAll(send2, receiveAll)
+            Log.Debug("Finished HttpLookupService test GetTopicsUnderNamespace function")
+        }
+
+        testTask "HttpLookupService test GetSchema function" {
+            Log.Debug("Started HttpLookupService test GetSchema function")
+            let client = getHttpLookupClient()
+            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+            let name = "autoProduceKeyValue"
+            let! (producer : IProducer<KeyValuePair<KeySchema, ValueSchema>>) =
+                client.NewProducer(Schema.KEY_VALUE<KeySchema, ValueSchema>(SchemaType.AVRO))
+                    .Topic(topicName)
+                    .ProducerName(name)
+                    .EnableBatching(false)
+                    .CreateAsync()
+            let! (producer2 : IProducer<byte[]>) =
+                client.NewProducer(Schema.AUTO_PRODUCE())
+                    .Topic(topicName)
+                    .ProducerName(name + "Main")
+                    .EnableBatching(false)
+                    .CreateAsync()
+            let! (consumer : IConsumer<KeyValuePair<KeySchema, ValueSchema>>) =
+                client.NewConsumer(Schema.KEY_VALUE<KeySchema, ValueSchema>(SchemaType.AVRO))
+                    .Topic(topicName)
+                    .ConsumerName(name)
+                    .SubscriptionName("test-subscription")
+                    .SubscribeAsync()
+            let keyInput = { KeySchema.Name = "abc"; Age = 20 }
+            let valueInput = { ValueSchema.Name = 20; Age = "abc" }
+            let! _ = producer.SendAsync(KeyValuePair(keyInput, valueInput))
+            let! (msg : Message<KeyValuePair<KeySchema, ValueSchema>>) = consumer.ReceiveAsync()
+            do! consumer.AcknowledgeAsync msg.MessageId
+            let (KeyValue(key, value)) = msg.GetValue()
+            Expect.equal "" keyInput key
+            Expect.equal "" valueInput value
+            let! _ = producer2.SendAsync(msg.Data)
+            let! (msg2 : Message<KeyValuePair<KeySchema, ValueSchema>>) = consumer.ReceiveAsync()
+            do! consumer.AcknowledgeAsync msg2.MessageId
+            let (KeyValue(key2, value2)) = msg2.GetValue()
+            Expect.equal "" keyInput key2
+            Expect.equal "" valueInput value2
+            do! consumer.UnsubscribeAsync()
+            Log.Debug("HttpLookupService test GetSchema function")
+        }
+    ]

--- a/tests/IntegrationTests/IntegrationTests.fsproj
+++ b/tests/IntegrationTests/IntegrationTests.fsproj
@@ -36,6 +36,7 @@
     <Compile Include="Failover.fs" />
     <Compile Include="Transaction.fs" />
     <Compile Include="MessageCrypto.fs" />
+    <Compile Include="HttpLookupService.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/UnitTests/Api/ServiceUriTests.fs
+++ b/tests/UnitTests/Api/ServiceUriTests.fs
@@ -25,6 +25,9 @@ module ServiceUriTests =
         let getOriginalString result =
             (result |> unwrap |> Option.get).OriginalString
 
+        let getScheme result =
+            (result |> unwrap |> Option.get).Scheme
+
         testList "ServiceUriTests" [
 
             test "Parse returns Error for null input" {
@@ -58,6 +61,16 @@ module ServiceUriTests =
                 Expect.equal actual expected "Parse should now pulsar scheme"
             }
 
+            test "Parse nows http scheme" {
+                let address = "http://host:8080"
+                let expectedAddress = Uri("http://host:8080")
+                let expectedScheme = "http"
+                let actualAddress = address |> ServiceUri.parse |> getAddresses |> List.head
+                let actualScheme = address |> ServiceUri.parse |> getScheme
+                Expect.equal actualAddress expectedAddress "Parse should now http address"
+                Expect.equal actualScheme expectedScheme "Parse should now http scheme"
+            }
+
             test "Parse nows secure pulsar scheme" {
                 let address = "pulsar+ssl://host:6650"
                 let expected = Uri("pulsar://host:6650")
@@ -77,6 +90,13 @@ module ServiceUriTests =
                 let expected = Uri("pulsar://host:6651")
                 let actual = address |> ServiceUri.parse |> getAddresses |> List.head
                 Expect.equal actual expected "Parse should set default port for secure pulsar scheme"
+            }
+
+            test "Parse sets default port for http scheme" {
+                let address = "http://host"
+                let expected = Uri("http://host:80")
+                let actual = address |> ServiceUri.parse |> getAddresses |> List.head
+                Expect.equal actual expected "Parse should set default port for http scheme"
             }
 
             test "Parse nows multiple hosts" {


### PR DESCRIPTION
support  https://github.com/fsprojects/pulsar-client-dotnet/issues/295

# Changes
- Add http protocol parse strategy in `ServiceUri`
- Add `ILookupService` as a lookup service interface
- Replace `BinaryLookupService` with `ILookupService` in internal classes declaration
- Add `HttpLookupService` integrated test cases