### PR TITLE
Support http lookup authentication(oauth2 and token)

### DIFF
--- a/src/Pulsar.Client/Api/AuthenticationDataProvider.fs
+++ b/src/Pulsar.Client/Api/AuthenticationDataProvider.fs
@@ -1,5 +1,6 @@
 ﻿namespace Pulsar.Client.Api
 
+open System.Collections.Generic
 open Pulsar.Client.Common
 open System.Text
 open System.Security.Cryptography.X509Certificates
@@ -25,6 +26,18 @@ type AuthenticationDataProvider() =
     abstract member GetCommandData: unit -> string
     default this.GetCommandData() =
         ""
+
+    //Http
+
+    abstract member HasDataForHttp: unit -> bool
+    default this.HasDataForHttp() =
+        false
+
+    abstract member GetHttpHeaders: unit -> IReadOnlyDictionary<string, string>
+    default this.GetHttpHeaders() =
+        Dictionary<string, string>()
+
+    //AuthDataProvider
 
     abstract member Authenticate: AuthData -> AuthData
     default this.Authenticate authData =

--- a/src/Pulsar.Client/Auth/AuthenticationDataToken.fs
+++ b/src/Pulsar.Client/Auth/AuthenticationDataToken.fs
@@ -1,5 +1,6 @@
 ﻿namespace Pulsar.Client.Auth    
 
+open System.Collections.Generic
 open Pulsar.Client.Api
 
 type internal AuthenticationDataToken (supplier: unit -> string) =
@@ -10,3 +11,17 @@ type internal AuthenticationDataToken (supplier: unit -> string) =
 
     override this.GetCommandData() =
         supplier()
+
+    override this.HasDataForHttp()=
+        true
+
+    //  Since AuthenticationOauth2 and AuthenticationToken both return this class when call GetAuthData()
+    //  We only need to realize this DataToken class GetHttpHeaders() to realize http authentication
+    override this.GetHttpHeaders()=
+        let httpHeaderPropertiesDict = Dictionary<string, string>()
+        httpHeaderPropertiesDict.Add("X-Pulsar-Auth-Method-Name", "token")
+        httpHeaderPropertiesDict.Add("Authorization", "Bearer " + supplier())
+        httpHeaderPropertiesDict
+
+
+

--- a/src/Pulsar.Client/Internal/BinaryLookupService.fs
+++ b/src/Pulsar.Client/Internal/BinaryLookupService.fs
@@ -137,7 +137,7 @@ type internal BinaryLookupService (config: PulsarClientConfiguration, connection
                 let requestId = Generators.getNextRequestId()
                 let payload = Commands.newGetTopicsOfNamespaceRequest ns requestId isPersistent
                 let! response = clientCnx.SendAndWaitForReply requestId payload |> Async.AwaitTask
-                let result = PulsarResponseType.GetTopicsOfNamespace response
+                let result = PulsarResponseType.GetTopicsOfNamespace response |> Seq.toArray
                 return result
             with Flatten ex ->
                 let delay = Math.Min(backoff.Next(), remainingTimeMs)

--- a/src/Pulsar.Client/Internal/HttpLookupService.fs
+++ b/src/Pulsar.Client/Internal/HttpLookupService.fs
@@ -3,7 +3,6 @@
 open System.Collections.Generic
 open System.IO
 open System.Net.Http
-open System.Text.Json.Serialization
 open Pulsar.Client.Api
 open Pulsar.Client.Common
 open System
@@ -15,14 +14,7 @@ open Pulsar.Client.Schema
 
 type internal HttpLookupService (config: PulsarClientConfiguration, _connectionPool: ConnectionPool) =
 
-    let httpClient = new HttpClient(new SocketsHttpHandler(
-        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
-        AllowAutoRedirect = true
-    ))
-    let jsonOptions = JsonSerializerOptions(
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-     )
-    do jsonOptions.Converters.Add(JsonStringEnumConverter())
+    let pulsarHttpClient = PulsarHttpClient(config)
 
     interface ILookupService with
 
@@ -57,8 +49,25 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                 return result
             }
 
+        //  GET /lookup/v2/topic/{topic-domain}/{tenant}/{namespace}/{topic}
         member this.GetBroker(topicName : CompleteTopicName) =
-            this.GetBrokerInner(topicName)
+            backgroundTask {
+                let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
+                let topic: string = %topicName
+                let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
+                let! brokerResponse =
+                    randomServiceUri.AbsoluteUri + $"lookup/v2/topic/%s{topicRestPath}"
+                    |> pulsarHttpClient.Get<{| BrokerUrl : string;
+                                               BrokerUrlTls: string;
+                                               HttpUrl: string;
+                                               HttpUrlTls: string |}>
+                let uri = if config.UseTls then
+                            Uri(brokerResponse.BrokerUrlTls)
+                          else
+                            Uri(brokerResponse.BrokerUrl)
+                let resultEndpoint = DnsEndPoint(uri.Host, uri.Port)
+                return { LogicalAddress = LogicalAddress resultEndpoint; PhysicalAddress = PhysicalAddress resultEndpoint }
+            }
 
         member this.GetTopicsUnderNamespace (ns: NamespaceName, isPersistent: bool) =
             backgroundTask {
@@ -91,11 +100,10 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                 let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
                 let topic: string = %topicName
                 let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
-                let! response =
+                let! brokerResponse =
                     randomServiceUri.AbsoluteUri + $"admin/v2/%s{topicRestPath}/partitions?checkAllowAutoCreation=true"
-                    |> httpClient.GetStreamAsync
+                    |> pulsarHttpClient.Get<{| Partitions: int |}>
                     |> Async.AwaitTask
-                let brokerResponse = JsonSerializer.Deserialize<{| Partitions: int |}>(response, jsonOptions)
                 return { Partitions = brokerResponse.Partitions }
 
             with Flatten ex ->
@@ -105,29 +113,6 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                 Log.Logger.LogWarning(ex, "GetPartitionedTopicMetadata failed will retry in {0} ms", nextDelay)
                 do! Async.Sleep nextDelay
                 return! this.GetPartitionedTopicMetadataInner(topicName, backoff, remainingTimeMs - nextDelay)
-        }
-
-    //  GET /lookup/v2/topic/{topic-domain}/{tenant}/{namespace}/{topic}
-    member private this.GetBrokerInner(topicName: CompleteTopicName) =
-        backgroundTask {
-            let randomServiceUri = config.ServiceAddresses[RandomGenerator.Next(0, config.ServiceAddresses.Length)]
-            let topic: string = %topicName
-            let topicRestPath = topic.Replace("persistent://","persistent/").Replace("non-persistent://","non-persistent/")
-            let! response = httpClient.GetStreamAsync (randomServiceUri.AbsoluteUri + $"lookup/v2/topic/%s{topicRestPath}")
-            let brokerResponse =
-                JsonSerializer.Deserialize<{|
-                    BrokerUrl : string
-                    BrokerUrlTls: string
-                    HttpUrl: string
-                    HttpUrlTls: string
-                |}>(response, jsonOptions)
-            let uri =
-                if config.UseTls then
-                    Uri(brokerResponse.BrokerUrlTls)
-                else
-                    Uri(brokerResponse.BrokerUrl)
-            let resultEndpoint = DnsEndPoint(uri.Host, uri.Port)
-            return { LogicalAddress = LogicalAddress resultEndpoint; PhysicalAddress = PhysicalAddress resultEndpoint }
         }
 
     //  GET /admin/v2/namespaces/{tenant}/{namespace}/topics?mode=PERSISTENT
@@ -140,11 +125,10 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                     match isPersistent with
                     | true -> "PERSISTENT"
                     | false -> "NON_PERSISTENT"
-                let! response =
+                let! brokerResponse =
                     randomServiceUri.AbsoluteUri + $"admin/v2/namespaces/%s{ns.ToString()}/topics?mode=%s{mode}"
-                    |> httpClient.GetStreamAsync
+                    |> pulsarHttpClient.Get<string[]>
                     |> Async.AwaitTask
-                let brokerResponse = JsonSerializer.Deserialize<string seq>(response, jsonOptions)
                 return brokerResponse
 
             with Flatten ex ->
@@ -174,18 +158,14 @@ type internal HttpLookupService (config: PulsarClientConfiguration, _connectionP
                         $"admin/v2/schemas/%s{topicRestPath}/schema/%d{schemaVersionInt}"
                     | None ->
                         $"admin/v2/schemas/%s{topicRestPath}/schema"
-                let! response =
+                let! schemaResponse =
                     randomServiceUri.AbsoluteUri + path
-                    |> httpClient.GetStreamAsync
+                    |> pulsarHttpClient.Get<{| Version : Int64;
+                                               Type: SchemaType;
+                                               Timestamp: Int64;
+                                               Data: string;
+                                               Properties: Dictionary<string, string> |}>
                     |> Async.AwaitTask
-                let schemaResponse =
-                    JsonSerializer.Deserialize<{|
-                        Version : Int64
-                        Type: SchemaType
-                        Timestamp: Int64
-                        Data: string
-                        Properties: Dictionary<string, string>
-                    |}>(response, jsonOptions)
                 let schemaData =
                     match schemaResponse.Type with
                     | SchemaType.KEY_VALUE -> schemaResponse.Data |> this.GetKeyValueSchemaBytes

--- a/src/Pulsar.Client/Internal/ILookupService.fs
+++ b/src/Pulsar.Client/Internal/ILookupService.fs
@@ -6,7 +6,7 @@ open System.Threading.Tasks
 type internal ILookupService =
 
     //  Get the partitions of the topic.
-    abstract member GetPartitionsForTopic: TopicName -> Task<TopicName array>
+    abstract member GetPartitionsForTopic: TopicName -> Task<TopicName[]>
 
     //  Get the partitions if the topic exists. Return "{partition: n}" if a partitioned topic exists;
     //  return "{partition: 0}" if a non-partitioned topic exists.
@@ -16,7 +16,7 @@ type internal ILookupService =
     abstract member GetBroker: CompleteTopicName -> Task<Broker>
 
     //  Returns all topics under the given namespace.
-    abstract member GetTopicsUnderNamespace: NamespaceName * isPersistent: bool -> Task<string seq>
+    abstract member GetTopicsUnderNamespace: NamespaceName * isPersistent: bool -> Task<string[]>
 
     //  Returns current SchemaInfo for a given topic.
     abstract member GetSchema: CompleteTopicName * ?schema: SchemaVersion -> Task<TopicSchema option>

--- a/src/Pulsar.Client/Internal/PulsarHttpClient.fs
+++ b/src/Pulsar.Client/Internal/PulsarHttpClient.fs
@@ -1,0 +1,43 @@
+﻿namespace Pulsar.Client.Internal
+
+open System.Net.Http
+open System.Net.Http.Json
+open System.Text.Json
+open System.Text.Json.Serialization
+open Pulsar.Client.Api
+open System
+
+//  This class is mainly used for http lookup service
+//  We name this class `PulsarHttpClient` to avoid naming clash with native HttpClient, and in Java pulsar client it's just `HttpClient`
+type internal PulsarHttpClient (config: PulsarClientConfiguration) =
+
+    let authenticationDataProvider = config.Authentication.GetAuthData()
+
+    let jsonOptions = JsonSerializerOptions(
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+     )
+    do jsonOptions.Converters.Add(JsonStringEnumConverter())
+
+    let httpClient = new HttpClient(new SocketsHttpHandler(
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+        AllowAutoRedirect = true
+    ))
+
+    member this.Get<'T> (requestUri: string) =
+        backgroundTask {
+            if authenticationDataProvider.HasDataForHttp() then
+                let request = new HttpRequestMessage(HttpMethod.Get, requestUri)
+                for headerPropertyEntry in authenticationDataProvider.GetHttpHeaders() do
+                    request.Headers.Add(headerPropertyEntry.Key, headerPropertyEntry.Value)
+                let! response = httpClient.SendAsync(request)
+                response.EnsureSuccessStatusCode() |> ignore
+                return! response.Content.ReadFromJsonAsync<'T>(jsonOptions)
+
+            else
+                return! httpClient.GetFromJsonAsync<'T>(requestUri, jsonOptions)
+        }
+
+
+
+
+

--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -139,6 +139,7 @@
     <Compile Include="Internal\EndPointResolver.fs" />
     <Compile Include="Internal\ILookupService.fs" />
     <Compile Include="Internal\BinaryLookupService.fs" />
+    <Compile Include="Internal\PulsarHttpClient.fs" />
     <Compile Include="Internal\HttpLookupService.fs" />
     <Compile Include="Internal\ConnectionHandler.fs" />
     <Compile Include="Internal\AcknowledgmentsGroupingTracker.fs" />

--- a/tests/UnitTests/Api/PulsarClientBuilderTests.fs
+++ b/tests/UnitTests/Api/PulsarClientBuilderTests.fs
@@ -39,4 +39,17 @@ module PulsarClientBuilderTests =
                     "Service Url needs to be specified on the PulsarClientBuilder object."
             }
 
+            test "Http lookup authentication authDataProvider" {
+                AuthenticationFactory.Token("test").GetAuthData().HasDataForHttp()
+                |> Expect.equal "AuthenticationToken HasDataForHttp should be true" true
+
+                AuthenticationFactoryOAuth2.ClientCredentials(
+                    Uri("https://test.com"),
+                    "test",
+                    Uri("https://test.com")
+                ).GetAuthMethodName()
+                |> Expect.equal "AuthenticationFactoryOAuth2 authData should be token" "token"
+            }
+
+
         ]


### PR DESCRIPTION
support https://github.com/fsprojects/pulsar-client-dotnet/issues/299

# Changes
- Add function `HasDataForHttp()` and `GetHttpHeaders()` in AuthenticationDataProvider type to generate http headers authentication properties
- Create a type class called PulsarHttpClient, this class will initialize authentication related members and expose a `GetStreamAsync()` function
- Replace `httpClient.GetStreamAsync()` with `pulsarHttpClient.GetStreamAsync()` in HttpLookupService to enable authentication