### PR TITLE
Split client TLS transport encryption from authentication

### DIFF
--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -17,6 +17,7 @@ type PulsarClientConfiguration =
         TlsHostnameVerificationEnable: bool
         TlsAllowInsecureConnection: bool
         TlsTrustCertificate: X509Certificate2
+        TlsCertificate: X509Certificate2
         Authentication: Authentication
         TlsProtocols: SslProtocols
         ListenerName: string
@@ -36,6 +37,7 @@ type PulsarClientConfiguration =
             TlsHostnameVerificationEnable = false
             TlsAllowInsecureConnection = false
             TlsTrustCertificate = null
+            TlsCertificate = null
             Authentication = Authentication.AuthenticationDisabled
             TlsProtocols = SslProtocols.None
             ListenerName = ""

--- a/src/Pulsar.Client/Api/PulsarClientBuilder.fs
+++ b/src/Pulsar.Client/Api/PulsarClientBuilder.fs
@@ -57,6 +57,11 @@ type PulsarClientBuilder private (config: PulsarClientConfiguration) =
         PulsarClientBuilder
             { config with
                 TlsTrustCertificate = tlsTrustCertificate }
+            
+    member this.TlsCertificate tlsCertificate =
+        PulsarClientBuilder
+            { config with
+                TlsCertificate = tlsCertificate }
 
     member this.Authentication authentication =
         PulsarClientBuilder

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -143,7 +143,18 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                         if config.UseTls then
                             Log.Logger.LogDebug("Configuring ssl for {0}", physicalAddress)
                             let sslStream = new SslStream(new NetworkStream(socket), false, RemoteCertificateValidationCallback(remoteCertificateValidationCallback))
-                            let clientCertificates = config.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
+                            let authData = config.Authentication.GetAuthData(physicalAddress.Host)
+                            let clientCertificates =
+                                if authData.HasDataForTls() then
+                                    config.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
+                                else
+                                    let clientCert = config.TlsCertificate
+                                    if clientCert = null then
+                                        X509Certificate2Collection([||])
+                                    elif not clientCert.HasPrivateKey then
+                                        failwith "TlsCertificate doesn't contain a private key"
+                                    else
+                                        X509Certificate2Collection([| clientCert |])
                             do! sslStream.AuthenticateAsClientAsync(physicalAddress.Host, clientCertificates, config.TlsProtocols, false)
 
                             let pipeConnection = StreamConnection.GetDuplex(sslStream, pipeOptions)

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -150,7 +150,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                                 else
                                     let clientCert = config.TlsCertificate
                                     if clientCert = null then
-                                        X509Certificate2Collection([||])
+                                        X509Certificate2Collection()
                                     elif not clientCert.HasPrivateKey then
                                         failwith "TlsCertificate doesn't contain a private key"
                                     else

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -29,7 +29,10 @@ let pulsarSslAddress = "pulsar+ssl://127.0.0.1:6651"
 // generate pfx file from pem, leave the password blank
 // openssl pkcs12 -in admin.cert.pem -inkey admin.key-pk8.pem -export -out admin.pfx
 let ca = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/ca.cert.pem")
+// Load the client certificate for the mtls encryption
+// The admin.pfx contains both client certificate and private key, which can be used for both mtls encryption and authentication.
 let clientCert = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/admin.pfx")
+// Use client certificate for tls authentication
 let sslAdmin = AuthenticationFactory.Tls(@"../ssl/admin.pfx")
 let sslUser1 = AuthenticationFactory.Tls(@"../ssl/user1.pfx")
 #endif

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -88,7 +88,7 @@ let sslTokenClient =
         .EnableTls(true)
         .TlsTrustCertificate(ca)
         .TlsCertificate(clientCert)
-        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.laYPAui-4eGFYxL4zcqYxLjV604wMDzAVe8PRww6NEI"))
+        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.aTnuZmrnskICGSoveSUtZt4RBVTOfiQM03nvBNuQU_o"))
         .BuildAsync().Result
 
 let sslUser1Client =

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -88,7 +88,7 @@ let sslTokenClient =
         .EnableTls(true)
         .TlsTrustCertificate(ca)
         .TlsCertificate(clientCert)
-        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.aTnuZmrnskICGSoveSUtZt4RBVTOfiQM03nvBNuQU_o"))
+        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.hkExtZmCXOi1byo_sVzZrxZcwN88tvVVMlNcxQEs3TY"))
         .BuildAsync().Result
 
 let sslUser1Client =

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -82,12 +82,13 @@ let sslAdminClient =
         .Authentication(sslAdmin)
         .BuildAsync().Result
 
-let sslMTlsEncryptionClient =
+let sslTokenClient =
     PulsarClientBuilder()
         .ServiceUrl(pulsarSslAddress)
         .EnableTls(true)
         .TlsTrustCertificate(ca)
         .TlsCertificate(clientCert)
+        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0LXVzZXIifQ.laYPAui-4eGFYxL4zcqYxLjV604wMDzAVe8PRww6NEI"))
         .BuildAsync().Result
 
 let sslUser1Client =
@@ -102,7 +103,7 @@ let getSslClient() = sslClient
 
 let getSslAdminClient() = sslAdminClient
 
-let getSslMTlsEncryptionClient() = sslMTlsEncryptionClient
+let getSSLTokenClient() = sslTokenClient
 
 let getSslUser1Client() = sslUser1Client
 #endif

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -103,7 +103,7 @@ let getSslClient() = sslClient
 
 let getSslAdminClient() = sslAdminClient
 
-let getSSLTokenClient() = sslTokenClient
+let getSslTokenClient() = sslTokenClient
 
 let getSslUser1Client() = sslUser1Client
 #endif

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -29,6 +29,7 @@ let pulsarSslAddress = "pulsar+ssl://127.0.0.1:6651"
 // generate pfx file from pem, leave the password blank
 // openssl pkcs12 -in admin.cert.pem -inkey admin.key-pk8.pem -export -out admin.pfx
 let ca = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/ca.cert.pem")
+let clientCert = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/admin.pfx")
 let sslAdmin = AuthenticationFactory.Tls(@"../ssl/admin.pfx")
 let sslUser1 = AuthenticationFactory.Tls(@"../ssl/user1.pfx")
 #endif
@@ -78,6 +79,14 @@ let sslAdminClient =
         .Authentication(sslAdmin)
         .BuildAsync().Result
 
+let sslMTlsEncryptionClient =
+    PulsarClientBuilder()
+        .ServiceUrl(pulsarSslAddress)
+        .EnableTls(true)
+        .TlsTrustCertificate(ca)
+        .TlsCertificate(clientCert)
+        .BuildAsync().Result
+
 let sslUser1Client =
     PulsarClientBuilder()
         .ServiceUrl(pulsarSslAddress)
@@ -89,6 +98,8 @@ let sslUser1Client =
 let getSslClient() = sslClient
 
 let getSslAdminClient() = sslAdminClient
+
+let getSslMTlsEncryptionClient() = sslMTlsEncryptionClient
 
 let getSslUser1Client() = sslUser1Client
 #endif

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -4,6 +4,7 @@
 
 open System
 open Expecto
+open Serilog
 
 open System.Threading.Tasks
 open Pulsar.Client.Api
@@ -11,9 +12,9 @@ open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 
 
-let tlsTransport client testName =
+let tlsTransport (client:PulsarClient) testName =
     testTask testName {
-        let client = getSslAdminClient()
+        Log.Debug("Started test: " + testName)
         let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
         let numberOfMessages = 10
         let messageIds = ResizeArray<MessageId>()

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -11,44 +11,47 @@ open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 
 
+let tlsTransport client testName =
+    testTask testName {
+        let client = getSslAdminClient()
+        let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+        let numberOfMessages = 10
+        let messageIds = ResizeArray<MessageId>()
+
+        let! (producer : IProducer<byte[]>) =
+            client.NewProducer()
+                .Topic(topicName)
+                .CreateAsync()
+
+        let! (consumer : IConsumer<byte[]>) =
+            client.NewConsumer()
+                .Topic(topicName)
+                .ConsumerName("concurrent")
+                .SubscriptionName("test-subscription")
+                .SubscribeAsync()
+
+        let producerTask =
+            Task.Run(fun () ->
+                task {
+                    do! produceMessages producer numberOfMessages "concurrent"
+                }:> Task)
+
+        let consumerTask =
+            Task.Run(fun () ->
+                task {
+                    for _ in 1..numberOfMessages do
+                        let! message = consumer.ReceiveAsync()
+                        messageIds.Add message.MessageId
+                    do! consumer.DisposeAsync()
+                }:> Task)
+
+        do! Task.WhenAll(producerTask, consumerTask)
+    }
+
 [<Tests>]
 let tests =
     testList "Tls" [
-        testTask "Tls transport" {
-            let client = getSslAdminClient()
-            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
-            let numberOfMessages = 10
-            let messageIds = ResizeArray<MessageId>()
-
-            let! (producer : IProducer<byte[]>) =
-                client.NewProducer()
-                    .Topic(topicName)
-                    .CreateAsync()
-
-            let! (consumer : IConsumer<byte[]>) =
-                client.NewConsumer()
-                    .Topic(topicName)
-                    .ConsumerName("concurrent")
-                    .SubscriptionName("test-subscription")
-                    .SubscribeAsync()
-
-            let producerTask =
-                Task.Run(fun () ->
-                    task {
-                        do! produceMessages producer numberOfMessages "concurrent"
-                    }:> Task)
-
-            let consumerTask =
-                Task.Run(fun () ->
-                    task {
-                        for _ in 1..numberOfMessages do
-                            let! message = consumer.ReceiveAsync()
-                            messageIds.Add message.MessageId
-                        do! consumer.DisposeAsync()
-                    }:> Task)
-
-            do! Task.WhenAll(producerTask, consumerTask)
-        }
-
+        tlsTransport (getSslAdminClient()) "Tls transport with mTls Authentication"
+        tlsTransport (getSslMTlsEncryptionClient()) "Tls transport with mTls Encryption"
     ]
 #endif

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -53,6 +53,6 @@ let tlsTransport (client:PulsarClient) testName =
 let tests =
     testList "Tls" [
         tlsTransport (getSslAdminClient()) "Tls transport with mTls Authentication"
-        tlsTransport (getSslMTlsEncryptionClient()) "Tls transport with mTls Encryption"
+        tlsTransport (getSSLTokenClient()) "Tls transport with token Authentication"
     ]
 #endif

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -14,7 +14,7 @@ open Pulsar.Client.IntegrationTests.Common
 
 let tlsTransport (client:PulsarClient) testName =
     testTask testName {
-        Log.Debug("Started test: " + testName)
+        Log.Debug("Started " + testName)
         let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
         let numberOfMessages = 10
         let messageIds = ResizeArray<MessageId>()
@@ -47,12 +47,13 @@ let tlsTransport (client:PulsarClient) testName =
                 }:> Task)
 
         do! Task.WhenAll(producerTask, consumerTask)
+        Log.Debug("Finished " + testName)
     }
 
 [<Tests>]
 let tests =
     testList "Tls" [
         tlsTransport (getSslAdminClient()) "Tls transport with mTls Authentication"
-        tlsTransport (getSSLTokenClient()) "Tls transport with token Authentication"
+        tlsTransport (getSslTokenClient()) "Tls transport with token Authentication"
     ]
 #endif

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -53,11 +53,13 @@ services:
       PULSAR_PREFIX_tlsTrustCertsFilePath: /pulsar/ssl/ca.cert.pem
       PULSAR_PREFIX_maxMessageSize: 10500000
       PULSAR_PREFIX_nettyMaxFrameSizeBytes: 10500000
+      PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect: true
+      PULSAR_PREFIX_tokenSecretKey: /pulsar/secret.key
       superUserRoles: admin
       brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls
       brokerClientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem
       authenticationEnabled: "true"
-      authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+      authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderTls,org.apache.pulsar.broker.authentication.AuthenticationProviderToken
       authorizationEnabled: "true"
       authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
       clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -42,7 +42,8 @@ services:
     ports:
       - "6651:6651"
     command: >
-      bash -c "bin/set_python_version.sh &&
+      bash -c "echo 'nSt7+qKTfU1kY6S8Dryrf+tGlMSDKH8od+JzW3sb41s=' > /pulsar/secret.key &&
+               bin/set_python_version.sh &&
                bin/apply-config-from-env.py conf/standalone.conf &&
                bin/pulsar standalone -nfw"
     environment:

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       PULSAR_PREFIX_maxMessageSize: 10500000
       PULSAR_PREFIX_nettyMaxFrameSizeBytes: 10500000
       PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect: true
-      PULSAR_PREFIX_tokenSecretKey: /pulsar/secret.key
+      PULSAR_PREFIX_tokenSecretKey: file:///pulsar/secret.key
       superUserRoles: admin
       brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls
       brokerClientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -42,8 +42,7 @@ services:
     ports:
       - "6651:6651"
     command: >
-      bash -c "echo 'nSt7+qKTfU1kY6S8Dryrf+tGlMSDKH8od+JzW3sb41s=' > /pulsar/secret.key &&
-               bin/set_python_version.sh &&
+      bash -c "bin/set_python_version.sh &&
                bin/apply-config-from-env.py conf/standalone.conf &&
                bin/pulsar standalone -nfw"
     environment:
@@ -55,7 +54,7 @@ services:
       PULSAR_PREFIX_maxMessageSize: 10500000
       PULSAR_PREFIX_nettyMaxFrameSizeBytes: 10500000
       PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect: true
-      PULSAR_PREFIX_tokenSecretKey: file:///pulsar/secret.key
+      PULSAR_PREFIX_tokenSecretKey: data:;base64,QVRnNCsyZkkvNnZyanVJQk1lcHFTTVBaZ1dsVlpjWXJJWFZ4RTRBWmExaz0=
       superUserRoles: admin
       brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls
       brokerClientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem

--- a/tests/compose/standalone/scripts/init-standalone-tls.sh
+++ b/tests/compose/standalone/scripts/init-standalone-tls.sh
@@ -13,4 +13,6 @@ bin/pulsar-admin tenants create public
 echo "Creating 'default' namespace..."
 bin/pulsar-admin namespaces create public/default
 
+echo "nSt7+qKTfU1kY6S8Dryrf+tGlMSDKH8od+JzW3sb41s=" > /pulsar/secret.key
+
 echo "Init Standalone TLS completed!"

--- a/tests/compose/standalone/scripts/init-standalone-tls.sh
+++ b/tests/compose/standalone/scripts/init-standalone-tls.sh
@@ -13,6 +13,4 @@ bin/pulsar-admin tenants create public
 echo "Creating 'default' namespace..."
 bin/pulsar-admin namespaces create public/default
 
-echo "nSt7+qKTfU1kY6S8Dryrf+tGlMSDKH8od+JzW3sb41s=" > /pulsar/secret.key
-
 echo "Init Standalone TLS completed!"


### PR DESCRIPTION
## Motivation

Bring PIP-158 https://github.com/apache/pulsar/issues/15289 to Pulsar.Client

## Modification

- Introduce a new client configuration: `TlsCertificate`. This combines `tlsKeyFilePath` and `tlsCertificateFilePath` from the Java client. Users need to provide both the certificate and private key in this configuration (the PFX file) for mTLS encryption. If the private key is missing, an exception will be thrown: "TlsCertificate doesn't contain a private key."
  
  - If `useTls` is enabled and TLS authentication data is absent, the client will use `TlsCertificate` as the client certificate for mTLS. This allows users to separate mTLS encryption configuration from authentication configuration, enabling the use of mTLS for encryption and other authentication method like JWT simultaneously.

## Usage

```csharp
var ca = new X509Certificate2(@"/path/to/ca.cert.crt");
var clientCert = new X509Certificate2(@"/path/to/client.pfx");
var client = await new PulsarClientBuilder()
    .ServiceUrl(serviceUrl)
    .TlsTrustCertificate(ca)
    .TlsCertificate(clientCert)
    .Authentication(AuthenticationFactory.Token("token_xxx"))
    .BuildAsync();
```

## Release

We should also cherry-pick this feature to branch 2.x