### PR TITLE
[2.x] Split client TLS transport encryption from authentication

### DIFF
--- a/src/Pulsar.Client/Api/Configuration.fs
+++ b/src/Pulsar.Client/Api/Configuration.fs
@@ -17,6 +17,7 @@ type PulsarClientConfiguration =
         TlsHostnameVerificationEnable: bool
         TlsAllowInsecureConnection: bool
         TlsTrustCertificate: X509Certificate2
+        TlsCertificate: X509Certificate2
         Authentication: Authentication
         TlsProtocols: SslProtocols
         ListenerName: string
@@ -36,6 +37,7 @@ type PulsarClientConfiguration =
             TlsHostnameVerificationEnable = false
             TlsAllowInsecureConnection = false
             TlsTrustCertificate = null
+            TlsCertificate = null
             Authentication = Authentication.AuthenticationDisabled
             TlsProtocols = SslProtocols.None
             ListenerName = ""

--- a/src/Pulsar.Client/Api/PulsarClientBuilder.fs
+++ b/src/Pulsar.Client/Api/PulsarClientBuilder.fs
@@ -57,6 +57,11 @@ type PulsarClientBuilder private (config: PulsarClientConfiguration) =
         PulsarClientBuilder
             { config with
                 TlsTrustCertificate = tlsTrustCertificate }
+            
+    member this.TlsCertificate tlsCertificate =
+        PulsarClientBuilder
+            { config with
+                TlsCertificate = tlsCertificate }
 
     member this.Authentication authentication =
         PulsarClientBuilder

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -143,7 +143,18 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                         if config.UseTls then
                             Log.Logger.LogDebug("Configuring ssl for {0}", physicalAddress)
                             let sslStream = new SslStream(new NetworkStream(socket), false, RemoteCertificateValidationCallback(remoteCertificateValidationCallback))
-                            let clientCertificates = config.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
+                            let authData = config.Authentication.GetAuthData(physicalAddress.Host)
+                            let clientCertificates =
+                                if authData.HasDataForTls() then
+                                    config.Authentication.GetAuthData(physicalAddress.Host).GetTlsCertificates()
+                                else
+                                    let clientCert = config.TlsCertificate
+                                    if clientCert = null then
+                                        X509Certificate2Collection()
+                                    elif not clientCert.HasPrivateKey then
+                                        failwith "TlsCertificate doesn't contain a private key"
+                                    else
+                                        X509Certificate2Collection([| clientCert |])
                             do! sslStream.AuthenticateAsClientAsync(physicalAddress.Host, clientCertificates, config.TlsProtocols, false)
 
                             let pipeConnection = StreamConnection.GetDuplex(sslStream, pipeOptions)

--- a/tests/IntegrationTests/Common.fs
+++ b/tests/IntegrationTests/Common.fs
@@ -29,6 +29,10 @@ let pulsarHttpAddress = "http://127.0.0.1:8080"
 // generate pfx file from pem, leave the password blank
 // openssl pkcs12 -in admin.cert.pem -inkey admin.key-pk8.pem -export -out admin.pfx
 let ca = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/ca.cert.pem")
+// Load the client certificate for the mtls encryption
+// The admin.pfx contains both client certificate and private key, which can be used for both mtls encryption and authentication.
+let clientCert = new Security.Cryptography.X509Certificates.X509Certificate2(@"../ssl/admin.pfx")
+// Use client certificate for tls authentication
 let sslAdmin = AuthenticationFactory.Tls(@"../ssl/admin.pfx")
 let sslUser1 = AuthenticationFactory.Tls(@"../ssl/user1.pfx")
 #endif
@@ -78,6 +82,15 @@ let sslAdminClient =
         .Authentication(sslAdmin)
         .BuildAsync().Result
 
+let sslTokenClient =
+    PulsarClientBuilder()
+        .ServiceUrl(pulsarSslAddress)
+        .EnableTls(true)
+        .TlsTrustCertificate(ca)
+        .TlsCertificate(clientCert)
+        .Authentication(AuthenticationFactory.Token("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.hkExtZmCXOi1byo_sVzZrxZcwN88tvVVMlNcxQEs3TY"))
+        .BuildAsync().Result
+
 let sslUser1Client =
     PulsarClientBuilder()
         .ServiceUrl(pulsarSslAddress)
@@ -89,6 +102,8 @@ let sslUser1Client =
 let getSslClient() = sslClient
 
 let getSslAdminClient() = sslAdminClient
+
+let getSslTokenClient() = sslTokenClient
 
 let getSslUser1Client() = sslUser1Client
 #endif

--- a/tests/IntegrationTests/Tls.fs
+++ b/tests/IntegrationTests/Tls.fs
@@ -4,6 +4,7 @@
 
 open System
 open Expecto
+open Serilog
 
 open System.Threading.Tasks
 open Pulsar.Client.Api
@@ -11,44 +12,48 @@ open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 
 
+let tlsTransport (client:PulsarClient) testName =
+    testTask testName {
+        Log.Debug("Started " + testName)
+        let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+        let numberOfMessages = 10
+        let messageIds = ResizeArray<MessageId>()
+
+        let! (producer : IProducer<byte[]>) =
+            client.NewProducer()
+                .Topic(topicName)
+                .CreateAsync()
+
+        let! (consumer : IConsumer<byte[]>) =
+            client.NewConsumer()
+                .Topic(topicName)
+                .ConsumerName("concurrent")
+                .SubscriptionName("test-subscription")
+                .SubscribeAsync()
+
+        let producerTask =
+            Task.Run(fun () ->
+                task {
+                    do! produceMessages producer numberOfMessages "concurrent"
+                }:> Task)
+
+        let consumerTask =
+            Task.Run(fun () ->
+                task {
+                    for _ in 1..numberOfMessages do
+                        let! message = consumer.ReceiveAsync()
+                        messageIds.Add message.MessageId
+                    do! consumer.DisposeAsync()
+                }:> Task)
+
+        do! Task.WhenAll(producerTask, consumerTask)
+        Log.Debug("Finished " + testName)
+    }
+
 [<Tests>]
 let tests =
     testList "Tls" [
-        testTask "Tls transport" {
-            let client = getSslAdminClient()
-            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
-            let numberOfMessages = 10
-            let messageIds = ResizeArray<MessageId>()
-            
-            let! (producer : IProducer<byte[]>) =
-                client.NewProducer()
-                    .Topic(topicName)
-                    .CreateAsync() 
-            
-            let! (consumer : IConsumer<byte[]>) =
-                client.NewConsumer()
-                    .Topic(topicName)
-                    .ConsumerName("concurrent")
-                    .SubscriptionName("test-subscription")
-                    .SubscribeAsync()
-                    
-            let producerTask =
-                Task.Run(fun () ->
-                    task {
-                        do! produceMessages producer numberOfMessages "concurrent"
-                    }:> Task)
-
-            let consumerTask =
-                Task.Run(fun () ->
-                    task {
-                        for _ in 1..numberOfMessages do
-                            let! message = consumer.ReceiveAsync()
-                            messageIds.Add message.MessageId
-                        do! consumer.DisposeAsync()
-                    }:> Task)
-
-            do! Task.WhenAll(producerTask, consumerTask) 
-        }
-
+        tlsTransport (getSslAdminClient()) "Tls transport with mTls Authentication"
+        tlsTransport (getSslTokenClient()) "Tls transport with token Authentication"
     ]
 #endif

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -52,11 +52,13 @@ services:
       PULSAR_PREFIX_tlsTrustCertsFilePath: /pulsar/ssl/ca.cert.pem
       PULSAR_PREFIX_maxMessageSize: 10500000
       PULSAR_PREFIX_nettyMaxFrameSizeBytes: 10500000
+      PULSAR_PREFIX_tlsRequireTrustedClientCertOnConnect: true
+      PULSAR_PREFIX_tokenSecretKey: data:;base64,QVRnNCsyZkkvNnZyanVJQk1lcHFTTVBaZ1dsVlpjWXJJWFZ4RTRBWmExaz0=
       superUserRoles: admin
       brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls
       brokerClientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem
       authenticationEnabled: "true"
-      authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderTls
+      authenticationProviders: org.apache.pulsar.broker.authentication.AuthenticationProviderTls,org.apache.pulsar.broker.authentication.AuthenticationProviderToken
       authorizationEnabled: "true"
       authorizationProvider: org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider
       clientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.AuthenticationTls


### PR DESCRIPTION
Cherry-pick https://github.com/fsprojects/pulsar-client-dotnet/pull/302 to branch 2.x

