### PR TITLE
Fix Pipeline stuck if the maxMessageSize is less than 32KB

### DIFF
--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -134,7 +134,11 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                                   broker, maxMessageSize)
         backgroundTask {
             let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
-            let pipeOptions = PipeOptions(pauseWriterThreshold = max (int64 maxMessageSize) 65536 )
+            // We should use PipeOptions.Default.PauseWriterThreshold as the minimum value for pauseWriterThreshold. A value that's too small isn't practical and will affect performance.
+            let pauseWriterThreshold = max (int64 maxMessageSize) PipeOptions.Default.PauseWriterThreshold
+            // Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance.
+            let resumeWriterThreshold = int64 (pauseWriterThreshold / 2L)
+            let pipeOptions = PipeOptions(pauseWriterThreshold = pauseWriterThreshold, resumeWriterThreshold = resumeWriterThreshold )
             let! socket = getSocket physicalAddress
 
             try

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -134,7 +134,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                                   broker, maxMessageSize)
         backgroundTask {
             let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
-            let pipeOptions = PipeOptions(pauseWriterThreshold = int64 maxMessageSize )
+            let pipeOptions = PipeOptions(pauseWriterThreshold = max (int64 maxMessageSize) 65536 )
             let! socket = getSocket physicalAddress
 
             try

--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -136,7 +136,7 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
             let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
             // We should use PipeOptions.Default.PauseWriterThreshold as the minimum value for pauseWriterThreshold. A value that's too small isn't practical and will affect performance.
             let pauseWriterThreshold = max (int64 maxMessageSize) PipeOptions.Default.PauseWriterThreshold
-            // Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance.
+            // Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance: https://github.com/dotnet/runtime/blob/970070e3b78b8cf604dabfe114e1f609c38c555d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs#L50-L51
             let resumeWriterThreshold = int64 (pauseWriterThreshold / 2L)
             let pipeOptions = PipeOptions(pauseWriterThreshold = pauseWriterThreshold, resumeWriterThreshold = resumeWriterThreshold )
             let! socket = getSocket physicalAddress


### PR DESCRIPTION
## Issue

If the maxMessageSize is configured in the broker is less than 32KB, producing the chunk message would get stuck.

### Reproduce

1. Start a pulsar standalone with `maxMessageSize=10240`
2. Create a producer with chunking enabled:

```csharp
           var producer = await client.NewProducer()
                .Topic(topicName)
                .EnableBatching(false)
                .EnableChunking(true)
                .CreateAsync();
```

3. Send a chunked message

```csharp
string largeString = new string('A', 30 * 1024);
var messageId = await producer.SendAsync(Encoding.UTF8.GetBytes($"Sent from C# at '{largeString}'"));
Console.WriteLine($"MessageId is: '{messageId}'");
```

4. The producer would get stuck here:

```
dbug: PulsarLogger[0]
      producer(0, standalone-70-4, -1) sendMessage sequenceId=0
dbug: PulsarLogger[0]
      producer(0, standalone-70-4, -1) CryptoKeyReader not present, encryption not possible
dbug: PulsarLogger[0]
      producer(0, standalone-70-4, -1) sendMessage sequenceId=0
dbug: PulsarLogger[0]
      clientCnx(5, LogicalAddres Unspecified/localhost:6650) Got message of type SendReceipt
dbug: PulsarLogger[0]
      producer(0, standalone-70-4, -1) Received ack for message (SequenceId=0,LedgerId=78,EntryId=0,HighestSequenceId=0)
```

It can only receive the first chunk of the chunked message.

## Motivation

The root cause is that if the Pipeline's `pauseWriterThreshold` is set to `maxMessageSize` and it's too small, it can disrupt other normal network operations.

The root cause is that the pauseWriterThreshold shouldn't be less than the resumeWriterThreshold. An additional validation has been added by this PR: https://github.com/dotnet/runtime/commit/b9691b06b96541e8e94cd79f17d6447b8d03ec20 and released in System.IO.Pipeline 9.0.0.

So if we upgrade the System.IO.Pipeline 9.0.0, it would throw the exception:
```
Unhandled exception. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'resumeWriterThreshold')
   at System.IO.Pipelines.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument)
   at System.IO.Pipelines.PipeOptions..ctor(MemoryPool`1 pool, PipeScheduler readerScheduler, PipeScheduler writerScheduler, Int64 pauseWriterThreshold, Int64 resumeWriterThreshold, Int32 minimumSegmentSize, Boolean useSynchronizationContext)
   at <StartupCode$Pulsar-Client>.$ConnectionPool.clo@135-33.MoveNext()
   at <StartupCode$Pulsar-Client>.$ConnectionPool.clo@135-33.MoveNext()
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.catchHandler@1(BinaryLookupService this, String topicName, Int32 remainingTimeMs, Backoff backoff, Exception _arg4)
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.GetPartitionedTopicMetadataInner@27-13.Invoke(Exception x)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 filterFunction, ExceptionDispatchInfo edi) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 547
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112
--- End of stack trace from previous location ---
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.GetPartitionedTopicMetadata@50.MoveNext()
   at <StartupCode$Pulsar-Client>.$PulsarClient.CreateProducerAsync@262.MoveNext()
   at Program.<Main>$(String[] args) in /Users/rbt/code/pulsar-client-dotnet/ConsoleApp1/Program.cs:line 22
   at Program.<Main>(String[] args)

```

I think we should set both the pauseWriterThreshold and the resumeWriterThreshold. It's recommended that the resumeWriterThreshold be half of the pauseWriterThreshold. We also need a minimum value for the pauseWriterThreshold, called DefaultPauseWriterThreshold. A value that's too small isn't practical and will affect performance.

## Modification

- Set a minimum value for `pauseWriterThreshold`. Use PipeOptions.Default.PauseWriterThreshold as the minimum value
- Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance.

## Test

I have tested it manually and it works well now.