### PR TITLE
[2.x] Fix Pipeline stuck if the maxMessageSize is less than 32KB (#304)

### DIFF
--- a/src/Pulsar.Client/Internal/ConnectionPool.fs
+++ b/src/Pulsar.Client/Internal/ConnectionPool.fs
@@ -134,7 +134,11 @@ type internal ConnectionPool (config: PulsarClientConfiguration) =
                                   broker, maxMessageSize)
         backgroundTask {
             let (PhysicalAddress physicalAddress) = broker.PhysicalAddress
-            let pipeOptions = PipeOptions(pauseWriterThreshold = int64 maxMessageSize )
+            // We should use PipeOptions.Default.PauseWriterThreshold as the minimum value for pauseWriterThreshold. A value that's too small isn't practical and will affect performance.
+            let pauseWriterThreshold = max (int64 maxMessageSize) PipeOptions.Default.PauseWriterThreshold
+            // Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance: https://github.com/dotnet/runtime/blob/970070e3b78b8cf604dabfe114e1f609c38c555d/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOptions.cs#L50-L51
+            let resumeWriterThreshold = int64 (pauseWriterThreshold / 2L)
+            let pipeOptions = PipeOptions(pauseWriterThreshold = pauseWriterThreshold, resumeWriterThreshold = resumeWriterThreshold )
             let! socket = getSocket physicalAddress
 
             try


### PR DESCRIPTION
Cherry-pick https://github.com/fsprojects/pulsar-client-dotnet/pull/304

## Motivation

The root cause is that if the Pipeline's `pauseWriterThreshold` is set to `maxMessageSize` and it's too small, it can disrupt other normal network operations.

The root cause is that the pauseWriterThreshold shouldn't be less than the resumeWriterThreshold. An additional validation has been added by this PR: https://github.com/dotnet/runtime/commit/b9691b06b96541e8e94cd79f17d6447b8d03ec20 and released in System.IO.Pipeline 9.0.0.

So if we upgrade the System.IO.Pipeline 9.0.0, it would throw the exception:
```
Unhandled exception. System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'resumeWriterThreshold')
   at System.IO.Pipelines.ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument argument)
   at System.IO.Pipelines.PipeOptions..ctor(MemoryPool`1 pool, PipeScheduler readerScheduler, PipeScheduler writerScheduler, Int64 pauseWriterThreshold, Int64 resumeWriterThreshold, Int32 minimumSegmentSize, Boolean useSynchronizationContext)
   at <StartupCode$Pulsar-Client>.$ConnectionPool.clo@135-33.MoveNext()
   at <StartupCode$Pulsar-Client>.$ConnectionPool.clo@135-33.MoveNext()
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.catchHandler@1(BinaryLookupService this, String topicName, Int32 remainingTimeMs, Backoff backoff, Exception _arg4)
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.GetPartitionedTopicMetadataInner@27-13.Invoke(Exception x)
   at Microsoft.FSharp.Control.AsyncPrimitives.CallFilterThenInvoke[T](AsyncActivation`1 ctxt, FSharpFunc`2 filterFunction, ExceptionDispatchInfo edi) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 547
   at Microsoft.FSharp.Control.Trampoline.Execute(FSharpFunc`2 firstAction) in D:\a\_work\1\s\src\FSharp.Core\async.fs:line 112
--- End of stack trace from previous location ---
   at <StartupCode$Pulsar-Client>.$BinaryLookupService.GetPartitionedTopicMetadata@50.MoveNext()
   at <StartupCode$Pulsar-Client>.$PulsarClient.CreateProducerAsync@262.MoveNext()
   at Program.<Main>$(String[] args) in /Users/rbt/code/pulsar-client-dotnet/ConsoleApp1/Program.cs:line 22
   at Program.<Main>(String[] args)

```

I think we should set both the pauseWriterThreshold and the resumeWriterThreshold. It's recommended that the resumeWriterThreshold be half of the pauseWriterThreshold. We also need a minimum value for the pauseWriterThreshold, called DefaultPauseWriterThreshold. A value that's too small isn't practical and will affect performance.

## Modification

- Set a minimum value for `pauseWriterThreshold`. Use PipeOptions.Default.PauseWriterThreshold as the minimum value
- Make sure the resumeWriterThreshold is half of the pauseWriterThreshold for better performance.

(cherry picked from commit aeb663a6178ba19f4b54d722ae01848831775d45)