### PR TITLE
Make consumer DisposeAsync execute in the backgroundTask

### DIFF
--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1671,7 +1671,9 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
             | Closing | Closed ->
                 ValueTask()
             | _ ->
-                postAndAsyncReply mb ConsumerMessage.Close |> ValueTask
+                backgroundTask {
+                    do! postAndAsyncReply mb ConsumerMessage.Close
+                } |> ValueTask
 
 
 and internal ZeroQueueConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration,

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -38,7 +38,7 @@ services:
 
   standaloneTls:
     hostname: standaloneTls
-    image: apachepulsar/pulsar-test-latest-version:latest
+    image: zhaijia/pulsar-test-latest-version:latest
     ports:
       - "6651:6651"
     command: >
@@ -66,7 +66,7 @@ services:
       clientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem
 
   initTls:
-    image: apachepulsar/pulsar-test-latest-version:latest
+    image: zhaijia/pulsar-test-latest-version:latest
     volumes:
       - ./scripts/wait-for-it.sh:/pulsar/bin/wait-for-it.sh
       - ./scripts/init-standalone-tls.sh:/pulsar/bin/init-standalone-tls.sh


### PR DESCRIPTION
## Motivation

The `producer.DisposeAsync` runs in the background, while the consumer does not. This can cause inconsistent behavior between closing the producer and the consumer. For example, if a user wants to wait for the result of `consumer.DisposeAsync` using `GetAwaiter`, it may lead to a deadlock if `ConfigureAwait(false)` is not set. It is better to run this dispose in the background to avoid deadlock issues and to ensure consistent behavior with the producer.
