### PR TITLE
[2.x] Make consumer DisposeAsync execute in the backgroundTask (#309)

### DIFF
--- a/.github/workflows/dotnetcore-ubuntu.yml
+++ b/.github/workflows/dotnetcore-ubuntu.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1678,7 +1678,9 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
             | Closing | Closed ->
                 ValueTask()
             | _ ->
-                postAndAsyncReply mb ConsumerMessage.Close |> ValueTask
+                backgroundTask {
+                    do! postAndAsyncReply mb ConsumerMessage.Close
+                } |> ValueTask
 
 
 and internal ZeroQueueConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clientConfig: PulsarClientConfiguration,

--- a/tests/compose/standalone/docker-compose.yml
+++ b/tests/compose/standalone/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   standaloneTls:
     hostname: standaloneTls
-    image: apachepulsar/pulsar-test-latest-version:latest
+    image: lanayx/pulsar-test-latest-version:latest
     ports:
       - "6651:6651"
     command: >
@@ -65,7 +65,7 @@ services:
       clientAuthenticationParameters: tlsCertFile:/pulsar/ssl/admin.cert.pem,tlsKeyFile:/pulsar/ssl/admin.key-pk8.pem
 
   initTls:
-    image: apachepulsar/pulsar-test-latest-version:latest
+    image: lanayx/pulsar-test-latest-version:latest
     volumes:
       - ./scripts/wait-for-it.sh:/pulsar/bin/wait-for-it.sh
       - ./scripts/init-standalone-tls.sh:/pulsar/bin/init-standalone-tls.sh


### PR DESCRIPTION
Cherry-pick: https://github.com/fsprojects/pulsar-client-dotnet/pull/309

## Motivation

The `producer.DisposeAsync` runs in the background, while the consumer does not. This can cause inconsistent behavior between closing the producer and the consumer. For example, if a user wants to wait for the result of `consumer.DisposeAsync` using `GetAwaiter`, it may lead to a deadlock if `ConfigureAwait(false)` is not set. It is better to run this dispose in the background to avoid deadlock issues and to ensure consistent behavior with the producer.

---------

Co-authored-by: Vladimir Shchur <odindafna2006@rambler.ru>
(cherry picked from commit 096bc2356b3e12ff9e77e1451abb6e977e9bc047)