### PR TITLE
Allow setting MemoryStreamManager via reflection

### DIFF
--- a/src/Pulsar.Client/Common/Tools.fs
+++ b/src/Pulsar.Client/Common/Tools.fs
@@ -11,8 +11,9 @@ open System.Collections.Generic
 open Microsoft.Extensions.Logging
 open System.Threading.Channels
 
-
-let MemoryStreamManager = RecyclableMemoryStreamManager()
+// MemoryStreamManager is mutable so that external programs may (unofficially) set their own RecyclableMemoryStreamManager via reflection (https://github.com/fsprojects/pulsar-client-dotnet/issues/320)
+// This is not part of the public API and may be changed anytime!
+let mutable MemoryStreamManager = RecyclableMemoryStreamManager()
 let MagicNumber = int16 0x0e01
 let RandomGenerator = Random()
 let EmptyProps: IReadOnlyDictionary<string, string> = readOnlyDict []


### PR DESCRIPTION
Hello, I would like to request this property to be mutable so that I can set my own MemoryStreamManager via reflection. (Because e.g. I want to set a low block size to decrease memory usage in a constrained environment, but these settings may not make sense for general usage)

I accept the risks of this approach, and don't wish to burden you with my issues, so I will cover it with tests on my side and accept it may be changed anytime.

Closes https://github.com/fsprojects/pulsar-client-dotnet/issues/320