### PR TITLE
OTEL activity key validation and decrease of log level

### DIFF
--- a/src/Pulsar.Client.Otel/OTelProducerInterceptor.fs
+++ b/src/Pulsar.Client.Otel/OTelProducerInterceptor.fs
@@ -42,6 +42,9 @@ type OTelProducerInterceptor<'T>(sourceName: string, log: ILogger) =
 
             if isNull activity then
                 message  //If there are no listeners interested in this activity, the activity above will be null.
+            elif not (mutableDict.ContainsKey activityKey) then
+                log.LogDebug("activityKey {0} is missing in dictionary. Check if OTEL propagators are configured correctly.", activityKey)
+                message //If listeners are not configured correctly, the attempt to find activityKey in dictionary would fail.
             else
                 activity
                     .SetTag("messaging.system", "pulsar")
@@ -99,4 +102,4 @@ type OTelProducerInterceptor<'T>(sourceName: string, log: ILogger) =
                 | _ ->
                     log.LogWarning("{0} Can't find start of activity for msgId={1}", prefix, messageId)
             | _ ->
-                log.LogWarning("{0} activity id is missing for msgId={1}", prefix, messageId)
+                log.LogDebug("{0} activity id is missing for msgId={1}", prefix, messageId)

--- a/src/Pulsar.Client.Otel/OtelConsumerInterceptor.fs
+++ b/src/Pulsar.Client.Otel/OtelConsumerInterceptor.fs
@@ -46,7 +46,7 @@ type OTelConsumerInterceptor<'T>(sourceName: string, log: ILogger) =
                     .Dispose()
             cache.Remove messageId |> ignore
         | _ ->
-            log.LogWarning("{0} Can't find start of activity for msgId={1}", prefix, messageId)
+            log.LogDebug("{0} Can't find start of activity for msgId={1}", prefix, messageId)
 
     let endPreviousActivities msgId (ackResult: AckResult) =
         cache.Keys


### PR DESCRIPTION
Add validation for activity key to avoid dictionary key not found exception if the OTEL activity or propagators are misconfigured.
Decrease the logging level for consumer and producer OTEL interceptors to avoid verbose warning if OTEL is NOT configured OR misconfigured.