### PR TITLE
Fix single topic consumer returning message ID with empty topic name

### DIFF
--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -452,7 +452,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
         ackRequests.Clear()
 
     let getNewIndividualMsgIdWithPartition messageId =
-        { messageId with Type = MessageIdType.Single; Partition = partitionIndex; TopicName = %"" }
+        { messageId with Type = MessageIdType.Single; Partition = partitionIndex; TopicName = topicName.CompleteTopicName }
 
     let processPossibleToDLQ (messageId : MessageId) =
         let acknowledge = trySendAcknowledge Individual EmptyProperties None
@@ -1351,7 +1351,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                     rawMessage.MessageId with
                         Partition = partitionIndex
                         Type = Batch(%i, acker)
-                        TopicName = %""
+                        TopicName = topicName.CompleteTopicName
                 }
                 let msgKey = singleMessageMetadata.PartitionKey
                 let getValue () =

--- a/tests/IntegrationTests/Basic.fs
+++ b/tests/IntegrationTests/Basic.fs
@@ -28,7 +28,7 @@ let tests =
 
             Log.Debug("Started Sent messageId should be equal to received messageId")
             let client = getClient()
-            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+            let topicName = "persistent://public/default/topic-" + Guid.NewGuid().ToString("N")
 
             let! (producer1 : IProducer<byte[]>) =
                 client.NewProducer()
@@ -54,9 +54,11 @@ let tests =
 
             Expect.isTrue "" (msg1Id = msg1.MessageId)
             Expect.equal "" [| 0uy |] <| msg1.GetValue()
+            Expect.equal "Message ID topic name should match" topicName (string msg1.MessageId.TopicName)
 
             Expect.isTrue "" (msg2Id = msg2.MessageId)
             Expect.equal "" [| 1uy |] <| msg2.GetValue()
+            Expect.equal "Message ID topic name should match" topicName (string msg2.MessageId.TopicName)
 
             Log.Debug("Finished Sent messageId should be equal to received messageId")
         }


### PR DESCRIPTION
## Motivation

Currently, the single topic consumer does not set the topic name for the returned message ID.  
This PR fixes the issue by ensuring that the topic name is correctly set.
