### PR TITLE
Fix receive getting stuck after seek in MultiTopicsConsumer

### DIFF
--- a/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
@@ -384,6 +384,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
     
     let clearIncomingMessages() =
         incomingMessages.Clear()
+        incomingMessagesSize <- 0L
         tryResumePoller()
 
     let dequeueMessage() =
@@ -766,7 +767,6 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                         unAckedMessageTracker.Clear()
                         clearIncomingMessages()
                         currentStream.RestartCompletedTasks()
-                        incomingMessagesSize <- 0L
                         channel |> Option.map _.SetResult() |> ignore
                     with ex ->
                         Log.Logger.LogError(ex, "{0} RedeliverUnacknowledgedMessages failed", prefix)
@@ -849,7 +849,6 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                         try
                             unAckedMessageTracker.Clear()
                             clearIncomingMessages()
-                            incomingMessagesSize <- 0L
                             let! _ =
                                 consumers
                                 |> Seq.map (fun (KeyValue(_, (consumer, _))) ->
@@ -868,7 +867,6 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                     try
                         unAckedMessageTracker.Clear()
                         clearIncomingMessages()
-                        incomingMessagesSize <- 0L
                         let! _ =
                             consumers
                             |> Seq.map (fun (KeyValue(_, (consumer, _))) -> consumer.SeekAsync(resolver))

--- a/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs
@@ -375,15 +375,23 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
         | Ok msg -> incomingMessagesSize <- incomingMessagesSize + msg.Data.LongLength
         | _ -> ()
         incomingMessages.Enqueue(m)
+        
+    let tryResumePoller() =
+        if isPollingAllowed() && (waitingPoller <> defaultWaitingPoller) then
+            Log.Logger.LogDebug("{0} resume poller", prefix)
+            waitingPoller.SetResult()
+            waitingPoller <- defaultWaitingPoller
+    
+    let clearIncomingMessages() =
+        incomingMessages.Clear()
+        tryResumePoller()
 
     let dequeueMessage() =
         let m = incomingMessages.Dequeue()
         match m with
         | Ok msg -> incomingMessagesSize <- incomingMessagesSize - msg.Data.LongLength
         | _ -> ()
-        if isPollingAllowed() && (waitingPoller <> defaultWaitingPoller) then
-            waitingPoller.SetResult()
-            waitingPoller <- defaultWaitingPoller
+        tryResumePoller()
         m
 
     let hasEnoughMessagesForBatchReceive() =
@@ -678,6 +686,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                         replyWithBatch ch
                 // check if should reply to poller immediately
                 if isPollingAllowed() |> not then
+                    Log.Logger.LogDebug("{0} paused poller, incomingMessages={1}, sharedQueueResumeThreshold={2}", prefix, incomingMessages.Count, sharedQueueResumeThreshold)
                     waitingPoller <- pollerChannel
                 else
                     pollerChannel.SetResult()
@@ -755,7 +764,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                             |> Seq.map(fun (KeyValue(_, (consumer, _))) -> consumer.RedeliverUnacknowledgedMessagesAsync())
                             |> Task.WhenAll
                         unAckedMessageTracker.Clear()
-                        incomingMessages.Clear()
+                        clearIncomingMessages()
                         currentStream.RestartCompletedTasks()
                         incomingMessagesSize <- 0L
                         channel |> Option.map _.SetResult() |> ignore
@@ -838,6 +847,9 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                     Log.Logger.LogDebug("{0} Seek {1}", prefix, seekData)
                     backgroundTask {
                         try
+                            unAckedMessageTracker.Clear()
+                            clearIncomingMessages()
+                            incomingMessagesSize <- 0L
                             let! _ =
                                 consumers
                                 |> Seq.map (fun (KeyValue(_, (consumer, _))) ->
@@ -845,9 +857,7 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
                                     | SeekType.Timestamp ts -> consumer.SeekAsync(ts)
                                     | SeekType.MessageId msgId -> consumer.SeekAsync(msgId))
                                 |> Task.WhenAll
-                            unAckedMessageTracker.Clear()
-                            incomingMessages.Clear()
-                            incomingMessagesSize <- 0L
+                            currentStream.RestartCompletedTasks()
                             channel.SetResult()
                         with Flatten ex ->
                             channel.SetException ex
@@ -856,13 +866,14 @@ type internal MultiTopicsConsumerImpl<'T> (consumerConfig: ConsumerConfiguration
             | SeekWithResolver (resolver, channel) ->
                 backgroundTask {
                     try
+                        unAckedMessageTracker.Clear()
+                        clearIncomingMessages()
+                        incomingMessagesSize <- 0L
                         let! _ =
                             consumers
                             |> Seq.map (fun (KeyValue(_, (consumer, _))) -> consumer.SeekAsync(resolver))
                             |> Task.WhenAll
-                        unAckedMessageTracker.Clear()
-                        incomingMessages.Clear()
-                        incomingMessagesSize <- 0L
+                        currentStream.RestartCompletedTasks()
                         channel.SetResult()
                     with Flatten ex ->
                         channel.SetException ex

--- a/tests/IntegrationTests/Seek.fs
+++ b/tests/IntegrationTests/Seek.fs
@@ -305,25 +305,28 @@ let tests =
             let cts = new CancellationTokenSource(TimeSpan.FromSeconds(30.0))
             
             try
-                try
-                    for _ in 1..numberOfMessages do
-                        let! (message : Message<byte[]>) = consumer.ReceiveAsync(cts.Token)
-                        let received = Encoding.UTF8.GetString(message.Data)
-                        Log.Debug("{0} received {1}", consumerName, received)
-                        receivedMessages.Add(received) |> ignore
-                        do! consumer.AcknowledgeAsync(message.MessageId)
-                    
-                    Expect.equal "" numberOfMessages receivedMessages.Count
-                    for expectedMsg in expectedMessages do
-                        Expect.isTrue "" (receivedMessages.Contains(expectedMsg))
-                with
-                | :? OperationCanceledException
-                | :? TaskCanceledException ->
-                    let errorMsg = $"Test timeout: Only received {receivedMessages.Count} out of {numberOfMessages} messages within 30 seconds"
-                    Log.Error(errorMsg)
-                    failwith errorMsg
-            finally
+                for _ in 1..numberOfMessages do
+                    let! (message : Message<byte[]>) = consumer.ReceiveAsync(cts.Token)
+                    let received = Encoding.UTF8.GetString(message.Data)
+                    Log.Debug("{0} received {1}", consumerName, received)
+                    receivedMessages.Add(received) |> ignore
+                    do! consumer.AcknowledgeAsync(message.MessageId)
+                
+                Expect.equal "" numberOfMessages receivedMessages.Count
+                for expectedMsg in expectedMessages do
+                    Expect.isTrue "" (receivedMessages.Contains(expectedMsg))
+                
                 cts.Dispose()
+            with
+            | :? OperationCanceledException
+            | :? TaskCanceledException ->
+                cts.Dispose()
+                let errorMsg = $"Test timeout: Only received {receivedMessages.Count} out of {numberOfMessages} messages within 30 seconds"
+                Log.Error(errorMsg)
+                failwith errorMsg
+            | ex ->
+                cts.Dispose()
+                raise ex
             
             Log.Debug("Finished Seek won't stuck the receive")
         }

--- a/tests/IntegrationTests/Seek.fs
+++ b/tests/IntegrationTests/Seek.fs
@@ -3,6 +3,7 @@ module Pulsar.Client.IntegrationTests.Seek
 open System
 open System.Threading
 open System.Diagnostics
+open System.Collections.Generic
 
 open Expecto
 open Expecto.Flip
@@ -239,6 +240,92 @@ let tests =
         
         testTask "Seek randomly works without batching " {
             do! testRandomSeek true 
+        }
+        
+        
+        testTask "Seek wont stuck the receive" {
+            Log.Debug("Started Seek wont stuck the receive")
+            let client = getClient()
+            let topicName = "persistent://public/default/multi-topic-seek"
+            let producerName = "seekStuckProducer"
+            let consumerName = "seekStuckConsumer"
+            let numberOfMessages = 30
+            let subscriptionName = "test-seek-stuck-" + Guid.NewGuid().ToString("N")
+            
+            let seekWithRetry (consumer: IConsumer<byte[]>) (targetTimestamp: TimeStamp) (maxRetries: int) =
+                task {
+                    let mutable retryCount = 0
+                    let mutable success = false
+                    while retryCount < maxRetries && not success do
+                        try
+                            do! consumer.SeekAsync(targetTimestamp)
+                            success <- true
+                        with Flatten ex ->
+                            match ex with
+                            | :? NotConnectedException as notConnectedEx ->
+                                retryCount <- retryCount + 1
+                                if retryCount >= maxRetries then
+                                    Log.Error("SeekAsync failed after {0} retries: {1}", maxRetries, notConnectedEx.Message)
+                                    raise notConnectedEx
+                                else
+                                    Log.Debug("SeekAsync failed (attempt {0}/{1}): {2}. Retrying in 1 second...", retryCount, maxRetries, notConnectedEx.Message)
+                                    do! Task.Delay(1000)
+                            | _ ->
+                                raise ex
+                }
+            
+            let! consumer =
+                client.NewConsumer()
+                    .Topic(topicName)
+                    .ConsumerName(consumerName)
+                    .SubscriptionName(subscriptionName)
+                    .ReceiverQueueSize(10)
+                    .SubscribeAsync()
+            let! (producer : IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .ProducerName(producerName)
+                    .EnableBatching(false)
+                    .CreateAsync()
+            
+            let expectedMessages = HashSet<string>()
+            for i in 1..numberOfMessages do
+                let messageContent = sprintf "Message-%i-%s" i (Guid.NewGuid().ToString("N"))
+                expectedMessages.Add(messageContent) |> ignore
+                let messageBytes = Encoding.UTF8.GetBytes(messageContent)
+                let! (_ : MessageId) = producer.SendAsync(messageBytes)
+                ()
+            do! Task.Delay(1000)
+            
+            let targetTimestamp = %(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - 1000L * 3600L * 24L)
+            Log.Debug("Seeking to timestamp: {0}", targetTimestamp)
+            do! seekWithRetry consumer targetTimestamp 10
+            
+            let receivedMessages = HashSet<string>()
+            let cts = new CancellationTokenSource(TimeSpan.FromSeconds(30.0))
+            
+            try
+                try
+                    for _ in 1..numberOfMessages do
+                        let! (message : Message<byte[]>) = consumer.ReceiveAsync(cts.Token)
+                        let received = Encoding.UTF8.GetString(message.Data)
+                        Log.Debug("{0} received {1}", consumerName, received)
+                        receivedMessages.Add(received) |> ignore
+                        do! consumer.AcknowledgeAsync(message.MessageId)
+                    
+                    Expect.equal "" numberOfMessages receivedMessages.Count
+                    for expectedMsg in expectedMessages do
+                        Expect.isTrue "" (receivedMessages.Contains(expectedMsg))
+                with
+                | :? OperationCanceledException
+                | :? TaskCanceledException ->
+                    let errorMsg = $"Test timeout: Only received {receivedMessages.Count} out of {numberOfMessages} messages within 30 seconds"
+                    Log.Error(errorMsg)
+                    failwith errorMsg
+            finally
+                cts.Dispose()
+            
+            Log.Debug("Finished Seek won't stuck the receive")
         }
        
     ]

--- a/tests/IntegrationTests/Seek.fs
+++ b/tests/IntegrationTests/Seek.fs
@@ -243,8 +243,8 @@ let tests =
         }
         
         
-        testTask "Seek wont stuck the receive" {
-            Log.Debug("Started Seek wont stuck the receive")
+        testTask "Seek won't get stuck at the receive in MultiTopicsConsumer" {
+            Log.Debug("Started Seek won't get stuck at the receive in MultiTopicsConsumer")
             let client = getClient()
             let topicName = "persistent://public/default/multi-topic-seek"
             let producerName = "seekStuckProducer"
@@ -328,7 +328,7 @@ let tests =
                 cts.Dispose()
                 raise ex
             
-            Log.Debug("Finished Seek won't stuck the receive")
+            Log.Debug("Finished Seek won't get stuck at the receive in MultiTopicsConsumer")
         }
        
     ]

--- a/tests/compose/standalone/scripts/init-standalone.sh
+++ b/tests/compose/standalone/scripts/init-standalone.sh
@@ -22,6 +22,7 @@ bin/pulsar-admin topics create-partitioned-topic persistent://public/default/par
 bin/pulsar-admin topics create-partitioned-topic persistent://public/default/partitioned6 --partitions 2
 bin/pulsar-admin topics create-partitioned-topic persistent://public/default/partitioned-dl-test --partitions 2
 bin/pulsar-admin topics create-partitioned-topic persistent://public/deduplication/partitioned --partitions 3
+bin/pulsar-admin topics create-partitioned-topic persistent://public/default/multi-topic-seek --partitions 3
 
 echo "Initializing transaction coordinator metadata..."
 bin/pulsar initialize-transaction-coordinator-metadata -cs standalone:2181 -c standalone --initial-num-transaction-coordinators 2


### PR DESCRIPTION
## Motivation

The `MultiTopicsConsumer` receive operation may become stuck after a `seek`. This could be reproduced using the newly added test "Seek wont stuck the receive".

The root cause is related to two issues described below.

### Issue 1: MultiTopicsConsumer poller may get stuck

The `MultiTopicsConsumer` poller is responsible for polling messages from all internal consumers and enqueueing them into the `incomingMessages` queue.

The poller may be paused when the `incomingMessages` count exceeds a configured threshold:
[https://github.com/fsprojects/pulsar-client-dotnet/blob/7e6df5684b2ee9a9ccb9acf67d138bf8be94ddbf/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs#L679-L683](https://github.com/fsprojects/pulsar-client-dotnet/blob/7e6df5684b2ee9a9ccb9acf67d138bf8be94ddbf/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs#L679-L683)

Under normal circumstances, the poller is expected to be resumed during a `Receive` operation:
[https://github.com/fsprojects/pulsar-client-dotnet/blob/7e6df5684b2ee9a9ccb9acf67d138bf8be94ddbf/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs#L384-L387](https://github.com/fsprojects/pulsar-client-dotnet/blob/7e6df5684b2ee9a9ccb9acf67d138bf8be94ddbf/src/Pulsar.Client/Internal/MultiTopicsConsumerImpl.fs#L384-L387)

However, during `seek` and `redeliver` operations, the `incomingMessages` queue is cleared without checking or resuming the poller. If the application is blocked waiting for new messages, the poller will never be resumed. It will only resume when the application explicitly invokes `Receive` again.

This PR fixes the issue by ensuring that the poller is checked and resumed whenever `incomingMessages` is cleared.

### Issue 2: incomingMessages is cleared after seek

The existing seek flow is as follows:

* `MultiTopicsConsumer` starts seek
* All internal consumers are instructed to seek
* Wait for all internal consumers to complete seek
  (during this phase, internal consumers may already push new messages to the mtConsumer)
* `MultiTopicsConsumer` clears the `incomingMessages` queue

This results in newly received messages being cleared unexpectedly, causing the user to miss messages and preventing `Receive` from returning data.

This PR changes the seek flow to the following order:

* `MultiTopicsConsumer` starts seek
* Clear `incomingMessages`
* Instruct all internal consumers to seek
* Wait for all internal consumers to complete seek
  (new messages pushed after this point are preserved)
* `MultiTopicsConsumer` can receive new messages successfully


With this change, it is possible for `MultiTopicsConsumer` to receive some old messages that were produced before the seek. This behavior is acceptable and consistent with current limitations.

A more robust solution to completely avoid receiving old messages would require implementing the approach discussed in https://github.com/apache/pulsar/issues/16757.

