### PR TITLE
Fix Reader HasMessageAvailable behavior after seeking by timestamp

### DIFF
--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1097,6 +1097,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             hasSoughtByTimestamp <- true
                             Commands.newSeekByTimestamp consumerId requestId timestamp, MessageId.Earliest
                         | SeekType.MessageId messageId ->
+                            hasSoughtByTimestamp <- false
                             match messageId.ChunkMessageIds with
                             | Some chunkMessageIds when chunkMessageIds.Length >0 ->
                                     Commands.newSeekByMsgId consumerId requestId chunkMessageIds[0], chunkMessageIds[0]
@@ -1144,9 +1145,12 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             try
                                 let! lastMessageIdResult = getLastMessageIdAsync()
                                 let lastMessageId = lastMessageIdResult.LastMessageId
-                                // if the consumer is configured to read inclusive then we need to seek to the last message
-                                do! postAndAsyncReply this.Mb (fun channel ->
-                                                SeekAsync (SeekType.MessageId lastMessageId, channel))
+                                // Only seek to the last message when the consumer starts from Latest AND is configured
+                                // to include the head. For timestamp-based seek, seeking again here would incorrectly
+                                // move the cursor to the end of the topic.
+                                if startMessageId = MessageId.Latest && consumerConfig.ResetIncludeHead && not hasSoughtByTimestamp then
+                                    do! postAndAsyncReply this.Mb (fun channel ->
+                                                    SeekAsync (SeekType.MessageId lastMessageId, channel))
                                 match lastMessageIdResult.MarkDeletePosition with
                                 | Some markDeletePosition ->
                                     if lastMessageId.EntryId < %0L then

--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -1145,10 +1145,8 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
                             try
                                 let! lastMessageIdResult = getLastMessageIdAsync()
                                 let lastMessageId = lastMessageIdResult.LastMessageId
-                                // Only seek to the last message when the consumer starts from Latest AND is configured
-                                // to include the head. For timestamp-based seek, seeking again here would incorrectly
-                                // move the cursor to the end of the topic.
-                                if startMessageId = MessageId.Latest && consumerConfig.ResetIncludeHead && not hasSoughtByTimestamp then
+                                // if the consumer is configured to read inclusive then we need to seek to the last message
+                                if consumerConfig.ResetIncludeHead && not hasSoughtByTimestamp then
                                     do! postAndAsyncReply this.Mb (fun channel ->
                                                     SeekAsync (SeekType.MessageId lastMessageId, channel))
                                 match lastMessageIdResult.MarkDeletePosition with

--- a/tests/IntegrationTests/Reader.fs
+++ b/tests/IntegrationTests/Reader.fs
@@ -350,6 +350,53 @@ let tests =
             
             Log.Debug("Finished HasMessageAvailableAfterSeekTimestamp initializeLastMessageIdInBroker: {0}", initializeLastMessageIdInBroker)
         }
+
+    let checkReaderLoopWhileHasMessageAvailableAfterSeekTimestamp () =
+        task {
+            Log.Debug("Started Reader loop while HasMessageAvailable after SeekTimestamp")
+            let client = getClient()
+            let topicName = "public/default/test-reader-loop-has-message-available-after-seek-timestamp-" + Guid.NewGuid().ToString("N")
+
+            let! (producer : IProducer<string>) =
+                client.NewProducer(Schema.STRING())
+                    .Topic(topicName)
+                    .EnableBatching(false)
+                    .CreateAsync()
+
+            let timestampBeforeSend = %(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+            let! _ = producer.SendAsync("m1")
+            let! _ = producer.SendAsync("m2")
+            let! _ = producer.SendAsync("m3")
+            do! producer.DisposeAsync()
+
+            let! (reader : IReader<string>) =
+                client.NewReader(Schema.STRING())
+                    .Topic(topicName)
+                    .ReceiverQueueSize(1)
+                    .StartMessageId(MessageId.Latest)
+                    .CreateAsync()
+
+            do! Task.Delay(1000)
+            do! reader.SeekAsync(timestampBeforeSend)
+            do! Task.Delay(1000)
+
+            use cts = new System.Threading.CancellationTokenSource(TimeSpan.FromSeconds(10.0))
+            let received = ResizeArray<string>()
+
+            let mutable continueLooping = true
+            while continueLooping do
+                let! hasMessage = reader.HasMessageAvailableAsync()
+                if hasMessage then
+                    let! msg = reader.ReadNextAsync(cts.Token)
+                    received.Add(msg.GetValue())
+                else
+                    continueLooping <- false
+
+            Expect.sequenceEqual "" [ "m1"; "m2"; "m3" ] received
+            do! reader.DisposeAsync()
+
+            Log.Debug("Finished Reader loop while HasMessageAvailable after SeekTimestamp")
+        }
     
     testList "Reader" [
 
@@ -407,5 +454,9 @@ let tests =
         
         testTask "HasMessageAvailable after SeekTimestamp with initializeLastMessageIdInBroker" {
             do! checkHasMessageAvailableAfterSeekTimestamp true 
+        }
+
+        testTask "Check HasMessageAvailable works after SeekTimestamp" {
+            do! checkReaderLoopWhileHasMessageAvailableAfterSeekTimestamp()
         }
     ]


### PR DESCRIPTION
## Motivation

Fixes: https://github.com/fsprojects/pulsar-client-dotnet/issues/340

The root cause is that after seeking by timestamp, the reader may incorrectly reset its cursor to the end of the topic inside HasMessageAvailable.

This PR also fixes an issue where hasSoughtByTimestamp is not reset to false when seeking by message ID.

Another issue is that this PR https://github.com/fsprojects/pulsar-client-dotnet/pull/192/changes#diff-d77a9b953c0d4a90fce3f3a201f6aa014df28eac2e9015b7e483184a4befd01eL1105 appears to have incorrectly removed the consumerConfig.ResetIncludeHead check in HasMessageAvailable. As a result, the reader may seek to the last message ID even when it is configured with exclusive reading to the latest ID, where this behavior is unnecessary. This PR restores the missing check to prevent that incorrect seek behavior.