### PR TITLE
Add client name to clientVersion

### DIFF
--- a/src/Pulsar.Client/Internal/ClientCnx.fs
+++ b/src/Pulsar.Client/Internal/ClientCnx.fs
@@ -117,7 +117,7 @@ and internal ClientCnx (config: PulsarClientConfiguration,
                 initialConnectionTsc: TaskCompletionSource<ClientCnx>,
                 unregisterClientCnx: Broker -> unit) as this =
 
-    let clientVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString()
+    let clientVersion = $"pulsar-client-dotnet-{Assembly.GetExecutingAssembly().GetName().Version.ToString()}"
     let protocolVersion =
         ProtocolVersion.GetValues(typeof<ProtocolVersion>)
         :?> ProtocolVersion[]

--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -7,17 +7,17 @@
     <Title>Pulsar.Client</Title>
     <RootNamespace>Pulsar.Client</RootNamespace>
     <AssemblyName>Pulsar.Client</AssemblyName>
-    <Version>3.14.0</Version>
+    <Version>3.14.1</Version>
     <Company>F# community</Company>
     <Description>.NET client library for Apache Pulsar</Description>
     <RepositoryUrl>https://github.com/fsprojects/pulsar-client-dotnet</RepositoryUrl>
-    <PackageReleaseNotes>Support for consumer epochs on seek and message redelivery</PackageReleaseNotes>
+    <PackageReleaseNotes>Added client name to reported clientVersion</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/fsprojects/pulsar-client-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Apache;Pulsar;F#;FSharp</PackageTags>
     <Authors>Vladimir Shchur and contributors</Authors>
-    <PackageVersion>3.14.0</PackageVersion>
+    <PackageVersion>3.14.1</PackageVersion>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/tests/IntegrationTests/Stats.fs
+++ b/tests/IntegrationTests/Stats.fs
@@ -1,9 +1,12 @@
 ﻿module Pulsar.Client.IntegrationTests.Stats
 
 open System
+open System.Text.Json
 open Expecto
 
 open System.Threading.Tasks
+open System.Reflection
+open Pulsar.Client.Api
 open Pulsar.Client.Common
 open Pulsar.Client.IntegrationTests.Common
 
@@ -55,5 +58,27 @@ let tests =
 
             Expect.equal consumerStats.TotalMsgsReceived numberOfMessages "The consumStats.TotalMsgsReceived is not equal to numberOfMessages"
             Expect.equal consumerStats.TotalAcksSent numberOfMessages "The consumStats.TotalAcksSent is not equal to numberOfMessages"
+        }
+
+        testTask "Broker topic stats should expose prefixed client version" {
+            let client = getClient()
+            let topicName = "public/default/topic-" + Guid.NewGuid().ToString("N")
+
+            let! (producer: IProducer<byte[]>) =
+                client.NewProducer()
+                    .Topic(topicName)
+                    .CreateAsync()
+
+            let! _ = producer.SendAsync([| 1uy |])
+            do! Task.Delay 3000
+
+            let url = $"{pulsarHttpAddress}/admin/v2/persistent/{topicName}/stats"
+            let! response : string = commonHttpClient.GetStringAsync(url)
+            let json = JsonDocument.Parse(response)
+            let publishers = json.RootElement.GetProperty("publishers")
+            let clientVersion = publishers[0].GetProperty("clientVersion").GetString()
+            let expectedVersion = $"pulsar-client-dotnet-{Assembly.GetAssembly(typeof<PulsarClient>).GetName().Version.ToString()}"
+
+            Expect.equal clientVersion expectedVersion "Expected broker stats to report the prefixed .NET client version."
         }
     ]


### PR DESCRIPTION

When the pulsar-client-dotnet client connects to the broker, the `clientVersion` field only shows the version number and does not include any client identity:

```
  "publishers" : [ {
    "accessMode" : "Shared",
    "msgRateIn" : 0.0,
    "msgThroughputIn" : 0.0,
    "averageMsgSize" : 0.0,
    "chunkedMessageRate" : 0.0,
    "producerId" : 0,
    "supportsPartialProducer" : false,
    "producerName" : "standalone-10-0",
    "address" : "/127.0.0.1:64415",
    "connectedSince" : "2026-03-30T16:26:48.035388+08:00",
    "clientVersion" : "3.13.1.0",
    "metadata" : { }
  } ],
```

As a result, we cannot distinguish which language client is being used.

This PR adds the client name as a prefix to the `clientVersion`, for example: `pulsar-client-dotnet-3.13.1.0`.
