### PR TITLE
Fix permit leak in consumer when handling a single message

### DIFF
--- a/src/Pulsar.Client/Internal/ConsumerImpl.fs
+++ b/src/Pulsar.Client/Internal/ConsumerImpl.fs
@@ -682,6 +682,7 @@ type internal ConsumerImpl<'T> (consumerConfig: ConsumerConfiguration<'T>, clien
         if duringSeek.IsSome || (isSameEntry(rawMessage.MessageId) && isPriorEntryIndex(rawMessage.MessageId.EntryId)) then
             // We need to discard entries that were prior to startMessageId
             Log.Logger.LogInformation("{0} Ignoring message from before the startMessageId: {1}", prefix, startMessageId)
+            increaseAvailablePermits 1
         else
             let msgKey = rawMessage.MessageKey
             let getValue () =


### PR DESCRIPTION
## Motivation

This PR fixes permit accounting when a consumer receives a single message that must be discarded because it is before `startMessageId` or arrives during `seek`.

Previously, that path dropped the message without delivering it to the application, but it still consumed one broker permit. Unlike normal delivered messages, this branch never reached the usual permit return path, so the consumer could gradually lose available credits. In practice, that could reduce throughput and, even cause receives to stall after a skipped message.

The fix keeps permit accounting consistent with the existing batch-message behavior: messages skipped before becoming externally visible must immediately return their permit. This preserves flow-control correctness and prevents credit leakage during seek/reset scenarios.

It's hard to test this case and the logic is easy to review. No tests are added in this PR.