### PR TITLE
Fix DateTime field not being encoded as a numeric timestamp in JSON schema

### DIFF
--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -7,17 +7,17 @@
     <Title>Pulsar.Client</Title>
     <RootNamespace>Pulsar.Client</RootNamespace>
     <AssemblyName>Pulsar.Client</AssemblyName>
-    <Version>3.15.1</Version>
+    <Version>3.15.2</Version>
     <Company>F# community</Company>
     <Description>.NET client library for Apache Pulsar</Description>
     <RepositoryUrl>https://github.com/fsprojects/pulsar-client-dotnet</RepositoryUrl>
-    <PackageReleaseNotes>Auto cluster failover refactoring</PackageReleaseNotes>
+    <PackageReleaseNotes>Fixed date representation for JSON schema</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/fsprojects/pulsar-client-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Apache;Pulsar;F#;FSharp</PackageTags>
     <Authors>Vladimir Shchur and contributors</Authors>
-    <PackageVersion>3.15.1</PackageVersion>
+    <PackageVersion>3.15.2</PackageVersion>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/Pulsar.Client/Schema/JsonSchema.fs
+++ b/src/Pulsar.Client/Schema/JsonSchema.fs
@@ -5,15 +5,34 @@ open System.Collections.Generic
 open System.Dynamic
 open System.Text
 open System.Text.Json
+open System.Text.Json.Serialization
 open Avro
 open Pulsar.Client.Api
 open AvroSchemaGenerator
 open Pulsar.Client.Common
 
+type internal DateTimeTimestampMillisConverter() =
+    inherit JsonConverter<DateTime>()
+    override this.Read(reader: byref<Utf8JsonReader>, _, _) =
+        match reader.TokenType with
+        | JsonTokenType.Number ->
+            reader.GetInt64()
+            |> DateTimeOffset.FromUnixTimeMilliseconds
+            |> _.UtcDateTime
+        | JsonTokenType.String ->
+            reader.GetDateTime()
+        | _ ->
+            raise <| JsonException $"Unexpected token parsing DateTime. Expected Number or String, got {reader.TokenType}."
+
+    override this.Write(writer: Utf8JsonWriter, value: DateTime, _) =
+        DateTimeOffset(value).ToUnixTimeMilliseconds()
+        |> writer.WriteNumberValue
+
 type internal JsonSchema<'T> () =
     inherit ISchema<'T>()
     let parameterIsClass =  typeof<'T>.IsClass
     let options = JsonSerializerOptions(IgnoreNullValues = true)
+    do options.Converters.Add(DateTimeTimestampMillisConverter())
     let stringSchema = typeof<'T>.GetSchema()
     override this.SchemaInfo = { Name = ""; Type = SchemaType.JSON; Schema = stringSchema |> Encoding.UTF8.GetBytes; Properties = Map.empty }
     override this.Encode value =

--- a/src/Pulsar.Client/Schema/JsonSchema.fs
+++ b/src/Pulsar.Client/Schema/JsonSchema.fs
@@ -2,7 +2,6 @@ namespace Pulsar.Client.Schema
 
 open System
 open System.Collections.Generic
-open System.Dynamic
 open System.Text
 open System.Text.Json
 open System.Text.Json.Serialization
@@ -34,7 +33,7 @@ type internal DateTimeTimestampMillisConverter() =
 type internal JsonSchema<'T> () =
     inherit ISchema<'T>()
     let parameterIsClass =  typeof<'T>.IsClass
-    let options = JsonSerializerOptions(IgnoreNullValues = true)
+    let options = JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
     do options.Converters.Add(DateTimeTimestampMillisConverter())
     let stringSchema = typeof<'T>.GetSchema()
     override this.SchemaInfo = { Name = ""; Type = SchemaType.JSON; Schema = stringSchema |> Encoding.UTF8.GetBytes; Properties = Map.empty }
@@ -47,7 +46,7 @@ type internal JsonSchema<'T> () =
 
 type internal GenericJsonSchema (topicSchema: TopicSchema) =
     inherit ISchema<GenericRecord>()
-    let dynamicSerializerOptions = JsonSerializerOptions(IgnoreNullValues = true)
+    let dynamicSerializerOptions = JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
     do dynamicSerializerOptions.Converters.Add <| DynamicJsonConverter()
     let stringSchema = topicSchema.SchemaInfo.Schema |> Encoding.UTF8.GetString
     let avroSchema = Schema.Parse(stringSchema) :?> RecordSchema
@@ -63,10 +62,10 @@ type internal GenericJsonSchema (topicSchema: TopicSchema) =
         let doc = JsonSerializer.Deserialize<IDictionary<string, obj>>(ReadOnlySpan bytes, dynamicSerializerOptions)
         let fields =
             schemaFields
-            |> Seq.map (fun sf -> { Name = sf.Name; Value = doc.[sf.Name]; Index = sf.Pos })
+            |> Seq.map (fun sf -> { Name = sf.Name; Value = doc[sf.Name]; Index = sf.Pos })
             |> Seq.toArray
-        let scemaVersionBytes =
-            topicSchema.SchemaVersion
-            |> Option.map _.Bytes
-            |> Option.toObj
-        GenericRecord(scemaVersionBytes, fields)
+        let schemaVersionBytes =
+            match topicSchema.SchemaVersion with
+            | Some v -> v.Bytes
+            | None -> null
+        GenericRecord(schemaVersionBytes, fields)

--- a/src/Pulsar.Client/Schema/JsonSchema.fs
+++ b/src/Pulsar.Client/Schema/JsonSchema.fs
@@ -13,6 +13,12 @@ open Pulsar.Client.Common
 
 type internal DateTimeTimestampMillisConverter() =
     inherit JsonConverter<DateTime>()
+    let normalizeToUtc (value: DateTime) =
+        if value.Kind = DateTimeKind.Utc then
+            value
+        else
+            DateTime.SpecifyKind(value, DateTimeKind.Utc)
+
     override this.Read(reader: byref<Utf8JsonReader>, _, _) =
         match reader.TokenType with
         | JsonTokenType.Number ->
@@ -25,7 +31,10 @@ type internal DateTimeTimestampMillisConverter() =
             raise <| JsonException $"Unexpected token parsing DateTime. Expected Number or String, got {reader.TokenType}."
 
     override this.Write(writer: Utf8JsonWriter, value: DateTime, _) =
-        DateTimeOffset(value).ToUnixTimeMilliseconds()
+        value
+        |> normalizeToUtc
+        |> DateTimeOffset
+        |> _.ToUnixTimeMilliseconds()
         |> writer.WriteNumberValue
 
 type internal JsonSchema<'T> () =

--- a/src/Pulsar.Client/Schema/JsonSchema.fs
+++ b/src/Pulsar.Client/Schema/JsonSchema.fs
@@ -13,26 +13,20 @@ open Pulsar.Client.Common
 
 type internal DateTimeTimestampMillisConverter() =
     inherit JsonConverter<DateTime>()
-    let normalizeToUtc (value: DateTime) =
-        if value.Kind = DateTimeKind.Utc then
-            value
-        else
-            DateTime.SpecifyKind(value, DateTimeKind.Utc)
 
     override this.Read(reader: byref<Utf8JsonReader>, _, _) =
         match reader.TokenType with
-        | JsonTokenType.Number ->
+        | JsonTokenType.Number -> // timestamp in milliseconds since Unix epoch
             reader.GetInt64()
             |> DateTimeOffset.FromUnixTimeMilliseconds
             |> _.UtcDateTime
-        | JsonTokenType.String ->
+        | JsonTokenType.String -> // ISO 8601 string
             reader.GetDateTime()
         | _ ->
             raise <| JsonException $"Unexpected token parsing DateTime. Expected Number or String, got {reader.TokenType}."
 
     override this.Write(writer: Utf8JsonWriter, value: DateTime, _) =
-        value
-        |> normalizeToUtc
+        value.ToUniversalTime()
         |> DateTimeOffset
         |> _.ToUnixTimeMilliseconds()
         |> writer.WriteNumberValue

--- a/tests/IntegrationTests/Schema.fs
+++ b/tests/IntegrationTests/Schema.fs
@@ -111,7 +111,13 @@ let tests =
                     .SubscriptionName("test-subscription")
                     .SubscribeAsync() 
 
-            let input = { SimpleRecord3.Name = "abc"; Age = 20; Date = DateTime.UtcNow }
+            // JSON schema encodes DateTime as timestamp-millis, so keep the
+            // expected value at the same precision used by the wire payload.
+            let inputDate =
+                DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+                |> DateTimeOffset.FromUnixTimeMilliseconds
+                |> _.UtcDateTime
+            let input = { SimpleRecord3.Name = "abc"; Age = 20; Date = inputDate }
             let! _ = producer.SendAsync(input) 
 
             let! (msg : Message<SimpleRecord3>) = consumer.ReceiveAsync() 

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -208,6 +208,25 @@ let tests =
             Expect.equal "" JsonValueKind.Number (doc.RootElement.GetProperty("OccurredAt").ValueKind)
         }
 
+        test "JSON schema DateTime encoding treats non-UTC values as UTC" {
+            let schema = Schema.JSON<DateTimeSchemaTest>()
+            let inputs = [
+                DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Local).AddTicks(715180L)
+                DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Unspecified).AddTicks(715180L)
+            ]
+
+            for input in inputs do
+                let payload = schema.Encode({ OccurredAt = input })
+                use doc = JsonDocument.Parse(payload)
+                let timestamp = doc.RootElement.GetProperty("OccurredAt").GetInt64()
+                let expected =
+                    DateTime.SpecifyKind(input, DateTimeKind.Utc)
+                    |> DateTimeOffset
+                    |> _.ToUnixTimeMilliseconds()
+
+                Expect.equal "" expected timestamp
+        }
+
         test "JSON schema DateTime decoding accepts numeric timestamp value" {
             let schema = Schema.JSON<DateTimeSchemaTest>()
             let expected = DateTimeOffset.FromUnixTimeMilliseconds(1776666603071L).UtcDateTime

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -208,7 +208,7 @@ let tests =
             Expect.equal "" JsonValueKind.Number (doc.RootElement.GetProperty("OccurredAt").ValueKind)
         }
 
-        test "JSON schema DateTime encoding treats non-UTC values as UTC" {
+        test "JSON schema DateTime encoding works for local and unspecified DateTime values" {
             let schema = Schema.JSON<DateTimeSchemaTest>()
             let inputs = [
                 DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Local).AddTicks(715180L)
@@ -220,7 +220,7 @@ let tests =
                 use doc = JsonDocument.Parse(payload)
                 let timestamp = doc.RootElement.GetProperty("OccurredAt").GetInt64()
                 let expected =
-                    DateTime.SpecifyKind(input, DateTimeKind.Utc)
+                    input
                     |> DateTimeOffset
                     |> _.ToUnixTimeMilliseconds()
 

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -199,31 +199,25 @@ let tests =
                 Expect.sequenceEqual "" input.Y output.Y
         }
 
-        test "JSON schema DateTime encoding writes numeric timestamp value" {
-            let schema = Schema.JSON<DateTimeSchemaTest>()
-            let input = { OccurredAt = DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Utc).AddTicks(715180L) }
-            let payload = schema.Encode(input)
-            use doc = JsonDocument.Parse(payload)
-
-            Expect.equal "" JsonValueKind.Number (doc.RootElement.GetProperty("OccurredAt").ValueKind)
-        }
-
-        test "JSON schema DateTime encoding works for local and unspecified DateTime values" {
+        test "JSON schema DateTime encoding works for all kinds of DateTime values" {
             let schema = Schema.JSON<DateTimeSchemaTest>()
             let inputs = [
                 DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Local).AddTicks(715180L)
                 DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Unspecified).AddTicks(715180L)
+                DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Utc).AddTicks(715180L)
             ]
 
             for input in inputs do
                 let payload = schema.Encode({ OccurredAt = input })
                 use doc = JsonDocument.Parse(payload)
-                let timestamp = doc.RootElement.GetProperty("OccurredAt").GetInt64()
+                let occuredAtProperty = doc.RootElement.GetProperty("OccurredAt")
+                Expect.equal "" JsonValueKind.Number occuredAtProperty.ValueKind
+                
+                let timestamp = occuredAtProperty.GetInt64()
                 let expected =
                     input
                     |> DateTimeOffset
                     |> _.ToUnixTimeMilliseconds()
-
                 Expect.equal "" expected timestamp
         }
 

--- a/tests/UnitTests/Internal/SchemaTests.fs
+++ b/tests/UnitTests/Internal/SchemaTests.fs
@@ -3,6 +3,8 @@ module Pulsar.Client.UnitTests.Internal.SchemaTests
 open System
 open System.Collections.Generic
 open System.Diagnostics
+open System.Text
+open System.Text.Json
 open AvroGenerated
 open Expecto
 open Expecto.Flip
@@ -25,6 +27,9 @@ type ProtobufSchemaTest = {
 
 [<CLIMutable>]
 type AvroSchemaTest = { X: string; Y: ResizeArray<int> }
+
+[<CLIMutable>]
+type DateTimeSchemaTest = { OccurredAt: DateTime }
 
 [<CLIMutable>]
 [<ProtoContract>]
@@ -192,6 +197,47 @@ let tests =
                     |> schema.Decode
                 Expect.equal "" input.X output.X
                 Expect.sequenceEqual "" input.Y output.Y
+        }
+
+        test "JSON schema DateTime encoding writes numeric timestamp value" {
+            let schema = Schema.JSON<DateTimeSchemaTest>()
+            let input = { OccurredAt = DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Utc).AddTicks(715180L) }
+            let payload = schema.Encode(input)
+            use doc = JsonDocument.Parse(payload)
+
+            Expect.equal "" JsonValueKind.Number (doc.RootElement.GetProperty("OccurredAt").ValueKind)
+        }
+
+        test "JSON schema DateTime decoding accepts numeric timestamp value" {
+            let schema = Schema.JSON<DateTimeSchemaTest>()
+            let expected = DateTimeOffset.FromUnixTimeMilliseconds(1776666603071L).UtcDateTime
+            let payload = Encoding.UTF8.GetBytes("""{"OccurredAt":1776666603071}""")
+
+            let output = schema.Decode(payload)
+
+            Expect.equal "" expected output.OccurredAt
+        }
+
+        test "JSON schema DateTime decoding accepts legacy string timestamp value" {
+            let schema = Schema.JSON<DateTimeSchemaTest>()
+            let expected = DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Utc).AddTicks(715180L)
+            let payload = Encoding.UTF8.GetBytes("""{"OccurredAt":"2026-04-20T06:30:03.071518Z"}""")
+
+            let output = schema.Decode(payload)
+
+            Expect.equal "" expected output.OccurredAt
+        }
+
+        test "Avro schema DateTime encoding writes numeric timestamp value" {
+            let schema = Schema.AVRO<DateTimeSchemaTest>()
+            let input = { OccurredAt = DateTime(2026, 4, 20, 6, 30, 3, DateTimeKind.Utc).AddTicks(715180L) }
+            use stream = new IO.MemoryStream(schema.Encode(input))
+            let decoder = Avro.IO.BinaryDecoder(stream)
+            let unionBranch = decoder.ReadLong()
+            let timestamp = decoder.ReadLong()
+
+            Expect.equal "" 1L unionBranch
+            Expect.equal "" (DateTimeOffset(input.OccurredAt).ToUnixTimeMilliseconds()) timestamp
         }
         
         test "Protobuf native" {


### PR DESCRIPTION


## Motivation

Currently, the `DateTime` field is encoded as a string in the JSON schema, which is inconsistent with the type defined in Avro:

```
"CreatedDate": "2026-04-20T06:30:03.071518Z"
```

Instead, JSON schema payloads should align with the generated Avro logical timestamp schema, rather than representing `DateTime` fields as ISO-formatted strings.

## Modification

* Add a `DateTime` JSON converter that outputs Unix epoch timestamps in milliseconds
* Update JSON schema decoding to support both numeric timestamps and legacy ISO string formats