### PR TITLE
fix:  bump snappier to 1.3.1

### DIFF
--- a/src/Pulsar.Client/Pulsar.Client.fsproj
+++ b/src/Pulsar.Client/Pulsar.Client.fsproj
@@ -45,7 +45,7 @@
     <PackageReference Include="protobuf-net" Version="3.2.30" />
     <PackageReference Include="zlib.net-mutliplatform" Version="1.0.6" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.3.6" />
-    <PackageReference Include="Snappier" Version="1.1.6" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
     <PackageReference Include="ZstdNet" Version="1.4.5" />
     <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />


### PR DESCRIPTION
<img width="1356" height="50" alt="image" src="https://github.com/user-attachments/assets/3ecfa397-7b20-467c-bae4-b8d986fae970" />
